### PR TITLE
Secure admin login

### DIFF
--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -1,13 +1,27 @@
 <?php
+session_set_cookie_params([
+    'lifetime' => 3600,
+    'path' => '/admin',
+    'httponly' => true,
+    'samesite' => 'Strict'
+]);
 session_start();
-$pass = getenv('ADMIN_PASS') ?: 'secret';
+$hash = getenv('ADMIN_PASS_HASH') ?: '$2y$12$EF2ZteyOXTqCYpP46/MuwuaYwPo/X5YuwlP1r14/BzQMco544Dnn6';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!empty($_POST['password']) && $_POST['password'] === $pass) {
+    if (empty($_POST['csrf_token']) || empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Ugyldig CSRF-token';
+    } elseif (!empty($_POST['password']) && password_verify($_POST['password'], $hash)) {
+        session_regenerate_id(true);
         $_SESSION['logged_in'] = true;
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
         header('Location: new_post.php');
         exit;
+    } else {
+        $error = 'Feil passord';
     }
-    $error = 'Feil passord';
+}
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
 ?>
 <!DOCTYPE html>
@@ -22,6 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
 <form method="post">
 <input type="password" name="password" placeholder="Passord" />
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Logg inn</button>
 </form>
 </body>

--- a/public/admin/new_post.php
+++ b/public/admin/new_post.php
@@ -1,20 +1,34 @@
 <?php
+session_set_cookie_params([
+    'lifetime' => 3600,
+    'path' => '/admin',
+    'httponly' => true,
+    'samesite' => 'Strict'
+]);
 session_start();
 if (empty($_SESSION['logged_in'])) {
     header('Location: index.php');
     exit;
 }
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 require_once __DIR__ . '/../api/db.php';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $title = $_POST['title'] ?? '';
-    $slug = $_POST['slug'] ?? '';
-    $content = $_POST['content'] ?? '';
-    if ($title && $slug && $content) {
-        $stmt = $pdo->prepare('INSERT INTO posts (slug, title, content, created_at) VALUES (?, ?, ?, NOW())');
-        $stmt->execute([$slug, $title, $content]);
-        $message = 'Lagret!';
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Ugyldig CSRF-token';
     } else {
-        $error = 'Alle felt må fylles';
+        $title = $_POST['title'] ?? '';
+        $slug = $_POST['slug'] ?? '';
+        $content = $_POST['content'] ?? '';
+        if ($title && $slug && $content) {
+            $stmt = $pdo->prepare('INSERT INTO posts (slug, title, content, created_at) VALUES (?, ?, ?, NOW())');
+            $stmt->execute([$slug, $title, $content]);
+            $message = 'Lagret!';
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        } else {
+            $error = 'Alle felt må fylles';
+        }
     }
 }
 ?>
@@ -33,6 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="text" name="title" placeholder="Tittel" />
 <input type="text" name="slug" placeholder="slug" />
 <textarea name="content" placeholder="Innhold"></textarea>
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Lagre</button>
 </form>
 </body>


### PR DESCRIPTION
## Summary
- Hash and verify admin passwords with `password_verify`
- Add CSRF protection to admin login and post creation forms
- Harden session handling with strict cookie settings and ID regeneration

## Testing
- `php -l public/admin/index.php`
- `php -l public/admin/new_post.php`


------
https://chatgpt.com/codex/tasks/task_e_688c8c8a9fd88328922867fc287d6abb