### PR TITLE
Add admin dashboard with post and collection management

### DIFF
--- a/public/admin/dashboard.php
+++ b/public/admin/dashboard.php
@@ -1,0 +1,49 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+// Fetch posts
+$postsStmt = $pdo->query('SELECT id, title, slug FROM posts ORDER BY created_at DESC');
+$posts = $postsStmt->fetchAll();
+// Fetch collections
+$collectionsStmt = $pdo->query('SELECT id, gamecode FROM collections ORDER BY id DESC');
+$collections = $collectionsStmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Admin Dashboard</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Dashboard</h1>
+<nav>
+    <a href="new_post.php">Ny artikkel</a> |
+    <a href="new_collection.php">Ny samling</a>
+</nav>
+<h2>Artikler</h2>
+<ul>
+<?php foreach ($posts as $post): ?>
+<li>
+    <?php echo htmlspecialchars($post['title']); ?>
+    [<a href="edit_post.php?id=<?php echo $post['id']; ?>">rediger</a>]
+    [<a href="delete_post.php?id=<?php echo $post['id']; ?>" onclick="return confirm('Slette?');">slett</a>]
+</li>
+<?php endforeach; ?>
+</ul>
+<h2>Samlinger</h2>
+<ul>
+<?php foreach ($collections as $col): ?>
+<li>
+    <?php echo htmlspecialchars($col['gamecode']); ?>
+    [<a href="edit_collection.php?id=<?php echo $col['id']; ?>">rediger</a>]
+    [<a href="delete_collection.php?id=<?php echo $col['id']; ?>" onclick="return confirm('Slette?');">slett</a>]
+</li>
+<?php endforeach; ?>
+</ul>
+</body>
+</html>

--- a/public/admin/delete_collection.php
+++ b/public/admin/delete_collection.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+$id = $_GET['id'] ?? '';
+if ($id) {
+    $stmt = $pdo->prepare('DELETE FROM collections WHERE id = ?');
+    $stmt->execute([$id]);
+}
+header('Location: dashboard.php');
+exit;

--- a/public/admin/delete_post.php
+++ b/public/admin/delete_post.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+$id = $_GET['id'] ?? '';
+if ($id) {
+    $stmt = $pdo->prepare('DELETE FROM posts WHERE id = ?');
+    $stmt->execute([$id]);
+}
+header('Location: dashboard.php');
+exit;

--- a/public/admin/edit_collection.php
+++ b/public/admin/edit_collection.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+$id = $_GET['id'] ?? '';
+if (!$id) {
+    header('Location: dashboard.php');
+    exit;
+}
+$stmt = $pdo->prepare('SELECT gamecode, data FROM collections WHERE id = ?');
+$stmt->execute([$id]);
+$col = $stmt->fetch();
+if (!$col) {
+    header('Location: dashboard.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Rediger samling</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Rediger samling</h1>
+<form method="post" action="update_collection.php">
+<input type="hidden" name="id" value="<?php echo $id; ?>" />
+<input type="text" name="gamecode" value="<?php echo htmlspecialchars($col['gamecode']); ?>" />
+<textarea name="data"><?php echo htmlspecialchars($col['data']); ?></textarea>
+<button type="submit">Oppdater</button>
+</form>
+</body>
+</html>

--- a/public/admin/edit_post.php
+++ b/public/admin/edit_post.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+$id = $_GET['id'] ?? '';
+if (!$id) {
+    header('Location: dashboard.php');
+    exit;
+}
+$stmt = $pdo->prepare('SELECT slug, title, content FROM posts WHERE id = ?');
+$stmt->execute([$id]);
+$post = $stmt->fetch();
+if (!$post) {
+    header('Location: dashboard.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Rediger artikkel</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Rediger artikkel</h1>
+<form method="post" action="update_post.php">
+<input type="hidden" name="id" value="<?php echo $id; ?>" />
+<input type="text" name="title" value="<?php echo htmlspecialchars($post['title']); ?>" />
+<input type="text" name="slug" value="<?php echo htmlspecialchars($post['slug']); ?>" />
+<textarea name="content"><?php echo htmlspecialchars($post['content']); ?></textarea>
+<button type="submit">Oppdater</button>
+</form>
+</body>
+</html>

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -4,7 +4,7 @@ $pass = getenv('ADMIN_PASS') ?: 'secret';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($_POST['password']) && $_POST['password'] === $pass) {
         $_SESSION['logged_in'] = true;
-        header('Location: new_post.php');
+        header('Location: dashboard.php');
         exit;
     }
     $error = 'Feil passord';

--- a/public/admin/new_collection.php
+++ b/public/admin/new_collection.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $gamecode = $_POST['gamecode'] ?? '';
+    $data = $_POST['data'] ?? '';
+    if ($gamecode && $data) {
+        $stmt = $pdo->prepare('INSERT INTO collections (gamecode, data) VALUES (?, ?)');
+        $stmt->execute([$gamecode, $data]);
+        $message = 'Lagret!';
+    } else {
+        $error = 'Alle felt må fylles';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Ny samling</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Ny samling</h1>
+<?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<form method="post">
+<input type="text" name="gamecode" placeholder="gamecode" />
+<textarea name="data" placeholder='{"games":[]}'></textarea>
+<button type="submit">Lagre</button>
+</form>
+</body>
+</html>

--- a/public/admin/update_collection.php
+++ b/public/admin/update_collection.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = $_POST['id'] ?? '';
+    $gamecode = $_POST['gamecode'] ?? '';
+    $data = $_POST['data'] ?? '';
+    if ($id && $gamecode && $data) {
+        $stmt = $pdo->prepare('UPDATE collections SET gamecode = ?, data = ? WHERE id = ?');
+        $stmt->execute([$gamecode, $data, $id]);
+    }
+}
+header('Location: dashboard.php');
+exit;

--- a/public/admin/update_post.php
+++ b/public/admin/update_post.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+if (empty($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once __DIR__ . '/../api/db.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = $_POST['id'] ?? '';
+    $title = $_POST['title'] ?? '';
+    $slug = $_POST['slug'] ?? '';
+    $content = $_POST['content'] ?? '';
+    if ($id && $title && $slug && $content) {
+        $stmt = $pdo->prepare('UPDATE posts SET title = ?, slug = ?, content = ? WHERE id = ?');
+        $stmt->execute([$title, $slug, $content, $id]);
+    }
+}
+header('Location: dashboard.php');
+exit;


### PR DESCRIPTION
## Summary
- Add admin dashboard listing blog posts and game collections with edit/delete links
- Implement CRUD handlers for posts and collections using prepared statements
- Provide forms for managing game collections stored as JSON

## Testing
- `find public -name "*.php" -exec php -l {} +`


------
https://chatgpt.com/codex/tasks/task_e_688c8c8adc8883289b99c03f1fcac8f0