### PR TITLE
Centralize input validation and sanitize admin forms

### DIFF
--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -2,7 +2,9 @@
 session_start();
 $pass = getenv('ADMIN_PASS') ?: 'secret';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!empty($_POST['password']) && $_POST['password'] === $pass) {
+    require_once __DIR__ . '/../api/validate.php';
+    $password = sanitize_field($_POST['password'] ?? '', 255);
+    if ($password !== false && hash_equals($pass, $password)) {
         $_SESSION['logged_in'] = true;
         header('Location: new_post.php');
         exit;

--- a/public/admin/new_post.php
+++ b/public/admin/new_post.php
@@ -4,17 +4,18 @@ if (empty($_SESSION['logged_in'])) {
     header('Location: index.php');
     exit;
 }
+require_once __DIR__ . '/../api/validate.php';
 require_once __DIR__ . '/../api/db.php';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $title = $_POST['title'] ?? '';
-    $slug = $_POST['slug'] ?? '';
-    $content = $_POST['content'] ?? '';
-    if ($title && $slug && $content) {
+    $title = sanitize_field($_POST['title'] ?? '', 255);
+    $slug = sanitize_field($_POST['slug'] ?? '', 100);
+    $content = sanitize_field($_POST['content'] ?? '', 10000);
+    if ($title !== false && $slug !== false && $content !== false && validate_slug($slug)) {
         $stmt = $pdo->prepare('INSERT INTO posts (slug, title, content, created_at) VALUES (?, ?, ?, NOW())');
         $stmt->execute([$slug, $title, $content]);
         $message = 'Lagret!';
     } else {
-        $error = 'Alle felt må fylles';
+        $error = 'Ugyldige data';
     }
 }
 ?>

--- a/public/api/article.php
+++ b/public/api/article.php
@@ -1,12 +1,13 @@
 <?php
 header('Content-Type: application/json');
+require_once __DIR__ . '/validate.php';
+require_once __DIR__ . '/db.php';
 $slug = $_GET['slug'] ?? '';
-if ($slug === '') {
+if ($slug === '' || !validate_slug($slug)) {
     http_response_code(400);
-    echo json_encode(['error' => 'Missing slug']);
+    echo json_encode(['error' => 'Invalid slug']);
     exit;
 }
-require_once __DIR__ . '/db.php';
 $stmt = $pdo->prepare('SELECT title, content, created_at FROM posts WHERE slug = ? LIMIT 1');
 $stmt->execute([$slug]);
 $post = $stmt->fetch();

--- a/public/api/articles.php
+++ b/public/api/articles.php
@@ -1,7 +1,21 @@
 <?php
 header('Content-Type: application/json');
+require_once __DIR__ . '/validate.php';
 require_once __DIR__ . '/db.php';
-$stmt = $pdo->query('SELECT id, slug, title, created_at FROM posts ORDER BY created_at DESC');
+$query = 'SELECT id, slug, title, created_at FROM posts ORDER BY created_at DESC';
+$params = [];
+if (isset($_GET['limit'])) {
+    $limit = validate_int($_GET['limit'], 1, 100);
+    if ($limit === false) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid limit']);
+        exit;
+    }
+    $query .= ' LIMIT ?';
+    $params[] = $limit;
+}
+$stmt = $pdo->prepare($query);
+$stmt->execute($params);
 $posts = $stmt->fetchAll();
 echo json_encode($posts);
 ?>

--- a/public/api/collection.php
+++ b/public/api/collection.php
@@ -1,12 +1,13 @@
 <?php
 header('Content-Type: application/json');
+require_once __DIR__ . '/validate.php';
+require_once __DIR__ . '/db.php';
 $gamecode = $_GET['gamecode'] ?? '';
-if ($gamecode === '') {
+if ($gamecode === '' || !validate_gamecode($gamecode)) {
     http_response_code(400);
-    echo json_encode(['error' => 'Missing gamecode']);
+    echo json_encode(['error' => 'Invalid gamecode']);
     exit;
 }
-require_once __DIR__ . '/db.php';
 $stmt = $pdo->prepare('SELECT data FROM collections WHERE gamecode = ? LIMIT 1');
 $stmt->execute([$gamecode]);
 $row = $stmt->fetch();

--- a/public/api/validate.php
+++ b/public/api/validate.php
@@ -1,0 +1,26 @@
+<?php
+function validate_slug(string $slug): bool {
+    return (bool) preg_match('/^[a-z0-9-]+$/', $slug);
+}
+
+function validate_gamecode(string $code): bool {
+    return (bool) preg_match('/^[A-Z0-9]{4,10}$/', $code);
+}
+
+function validate_int(string $value, int $min, int $max) {
+    if (!preg_match('/^\d+$/', $value)) {
+        return false;
+    }
+    $int = (int) $value;
+    return ($int >= $min && $int <= $max) ? $int : false;
+}
+
+function sanitize_field(string $value, int $maxLen) {
+    $value = trim($value);
+    $value = strip_tags($value);
+    if ($value === '' || strlen($value) > $maxLen) {
+        return false;
+    }
+    return $value;
+}
+?>


### PR DESCRIPTION
## Summary
- add shared validation helpers for slugs, game codes, integers, and text sanitization
- whitelist and validate API query parameters in article, articles, and collection endpoints
- sanitize and length-check admin form submissions before database use

## Testing
- `php -l public/api/article.php`
- `php -l public/api/articles.php`
- `php -l public/api/collection.php`
- `php -l public/api/validate.php`
- `php -l public/admin/index.php`
- `php -l public/admin/new_post.php`


------
https://chatgpt.com/codex/tasks/task_e_688c8c8bcc088328be518ae6ffad117e