### PR TITLE
Add public loadCollection helper

### DIFF
--- a/public/data/loadCollection.js
+++ b/public/data/loadCollection.js
@@ -1,0 +1,11 @@
+export async function loadCollection(gamecode = 'FEST123') {
+  try {
+    const res = await fetch(`/api/collection.php?gamecode=${gamecode}`);
+    if (!res.ok) throw new Error('Klarte ikke å laste spillmodusen.');
+    const data = await res.json();
+    return data;
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- copy `loadCollection` from `src/data` to `public/data`
- confirm `ModeSelector` still references `../data/loadCollection.js`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -sS 'http://127.0.0.1:8000/api/collection.php?gamecode=FEST123'` *(Database connection failed)*
- `node --input-type=module` call to `loadCollection()` *(Database connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688c9378eb4883289f04ee3eab12f73d