### PR TITLE
feat: enhance service worker caching

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,22 +1,52 @@
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `gamenight-cache-${CACHE_VERSION}`;
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/styles/main.css',
+  '/main.js',
+  '/components/ChallengeCard.js',
+  '/components/ModeSelector.js',
+  '/components/PlayerInput.js',
+  '/components/init.js',
+  '/GameNight-logo-small.webp',
+  '/gamenight_ikon.png',
+  '/backgrounds/challenge.jpg',
+  '/backgrounds/jegharaldri.jpg',
+  '/backgrounds/main.jpg',
+  '/backgrounds/spillthetea.jpg',
+  '/backgrounds/yayornay.jpg',
+  '/titles/challenge.png',
+  '/titles/jegharaldri.png',
+  '/titles/spillthetea.png',
+  '/titles/yayornay.png'
+];
+
 self.addEventListener('install', event => {
   console.log('Service Worker installing...');
   event.waitUntil(
-    caches.open('gamenight-cache-v1').then(cache => {
-      return cache.addAll([
-        '/',
-        '/index.html',
-        '/manifest.json',
-        '/styles/main.css',
-        '/main.js'
-      ]);
-    })
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
   );
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(response => {
-      return response || fetch(event.request);
-    })
+    caches.match(event.request).then(response => response || fetch(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- precache component scripts, images, and styles
- version caches and remove outdated entries on activation
- serve index.html as offline fallback for navigation requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c94f8a7808328995ebc94d6517daf