### PR TITLE
Add inline player validation and management

### DIFF
--- a/public/components/PlayerInput.js
+++ b/public/components/PlayerInput.js
@@ -7,25 +7,35 @@ export function renderPlayerInput() {
     <ul id="playerList"></ul>
     <input id="playerName" placeholder="Spillernavn" />
     <button id="addPlayer">Legg til</button>
+    <p id="playerMessage" style="color: red;"></p>
     <button id="continue">Fortsett</button>
   \`;
 
   const playerList = document.getElementById('playerList');
   const players = [];
 
+  const message = document.getElementById('playerMessage');
+
   document.getElementById('addPlayer').addEventListener('click', () => {
     const input = document.getElementById('playerName');
     const name = input.value.trim();
-    if (name) {
-      players.push(name);
-      updateList();
-      input.value = '';
+    if (!name) {
+      message.textContent = 'Skriv inn et navn.';
+      return;
     }
+    if (players.includes(name)) {
+      message.textContent = 'Navnet er allerede lagt til.';
+      return;
+    }
+    players.push(name);
+    updateList();
+    input.value = '';
+    message.textContent = '';
   });
 
   document.getElementById('continue').addEventListener('click', () => {
     if (players.length < 2) {
-      alert('Legg til minst to spillere!');
+      message.textContent = 'Legg til minst to spillere!';
       return;
     }
     localStorage.setItem('players', JSON.stringify(players));
@@ -34,9 +44,19 @@ export function renderPlayerInput() {
 
   function updateList() {
     playerList.innerHTML = '';
-    players.forEach(p => {
+    players.forEach((p, index) => {
       const li = document.createElement('li');
       li.textContent = p;
+      const del = document.createElement('button');
+      del.textContent = 'Slett';
+      del.addEventListener('click', () => {
+        players.splice(index, 1);
+        updateList();
+        if (players.length >= 2) {
+          message.textContent = '';
+        }
+      });
+      li.appendChild(del);
       playerList.appendChild(li);
     });
   }

--- a/public/main.js
+++ b/public/main.js
@@ -52,23 +52,38 @@ function m() {
     <ul id="playerList"></ul>
     <input id="playerName" placeholder="Spillernavn" />
     <button id="addPlayer">Legg til</button>
+    <p id="playerMessage" style="color: red;"></p>
     <button id="continue">Fortsett</button>
   `;
-  const e = document.getElementById("playerList"), t = [];
+  const e = document.getElementById("playerList"), t = [], n = document.getElementById("playerMessage");
   document.getElementById("addPlayer").addEventListener("click", () => {
     const o = document.getElementById("playerName"), a = o.value.trim();
-    a && (t.push(a), r(), o.value = "");
+    if (!a) {
+      n.textContent = "Skriv inn et navn.";
+      return;
+    }
+    if (t.includes(a)) {
+      n.textContent = "Navnet er allerede lagt til.";
+      return;
+    }
+    t.push(a), r(), o.value = "", n.textContent = "";
   }), document.getElementById("continue").addEventListener("click", () => {
     if (t.length < 2) {
-      alert("Legg til minst to spillere!");
+      n.textContent = "Legg til minst to spillere!";
       return;
     }
     localStorage.setItem("players", JSON.stringify(t)), p();
   });
   function r() {
-    e.innerHTML = "", t.forEach((o) => {
+    e.innerHTML = "", t.forEach((o, i) => {
       const a = document.createElement("li");
-      a.textContent = o, e.appendChild(a);
+      a.textContent = o;
+      const c = document.createElement("button");
+      c.textContent = "Slett";
+      c.addEventListener("click", () => {
+        t.splice(i, 1), r(), t.length >= 2 && (n.textContent = "");
+      });
+      a.appendChild(c), e.appendChild(a);
     });
   }
 }

--- a/src/components/PlayerInput.js
+++ b/src/components/PlayerInput.js
@@ -7,25 +7,35 @@ export function renderPlayerInput() {
     <ul id="playerList"></ul>
     <input id="playerName" placeholder="Spillernavn" />
     <button id="addPlayer">Legg til</button>
+    <p id="playerMessage" style="color: red;"></p>
     <button id="continue">Fortsett</button>
   `;
 
   const playerList = document.getElementById('playerList');
   const players = [];
 
+  const message = document.getElementById('playerMessage');
+
   document.getElementById('addPlayer').addEventListener('click', () => {
     const input = document.getElementById('playerName');
     const name = input.value.trim();
-    if (name) {
-      players.push(name);
-      updateList();
-      input.value = '';
+    if (!name) {
+      message.textContent = 'Skriv inn et navn.';
+      return;
     }
+    if (players.includes(name)) {
+      message.textContent = 'Navnet er allerede lagt til.';
+      return;
+    }
+    players.push(name);
+    updateList();
+    input.value = '';
+    message.textContent = '';
   });
 
   document.getElementById('continue').addEventListener('click', () => {
     if (players.length < 2) {
-      alert('Legg til minst to spillere!');
+      message.textContent = 'Legg til minst to spillere!';
       return;
     }
     localStorage.setItem('players', JSON.stringify(players));
@@ -34,9 +44,19 @@ export function renderPlayerInput() {
 
   function updateList() {
     playerList.innerHTML = '';
-    players.forEach(p => {
+    players.forEach((p, index) => {
       const li = document.createElement('li');
       li.textContent = p;
+      const del = document.createElement('button');
+      del.textContent = 'Slett';
+      del.addEventListener('click', () => {
+        players.splice(index, 1);
+        updateList();
+        if (players.length >= 2) {
+          message.textContent = '';
+        }
+      });
+      li.appendChild(del);
       playerList.appendChild(li);
     });
   }


### PR DESCRIPTION
## Summary
- Replace alert with inline validation message for missing or duplicate players
- Prevent adding duplicate player names
- Provide delete buttons in player list items to remove players

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c9e52dba08328bebecfb507bb150c