### PR TITLE
Validate API input formats

### DIFF
--- a/public/api/article.php
+++ b/public/api/article.php
@@ -6,6 +6,11 @@ if ($slug === '') {
     echo json_encode(['error' => 'Missing slug']);
     exit;
 }
+if (!preg_match('/^[a-z0-9-]{1,64}$/', $slug)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid slug format']);
+    exit;
+}
 require_once __DIR__ . '/db.php';
 $stmt = $pdo->prepare('SELECT title, content, created_at FROM posts WHERE slug = ? LIMIT 1');
 $stmt->execute([$slug]);

--- a/public/api/collection.php
+++ b/public/api/collection.php
@@ -6,6 +6,11 @@ if ($gamecode === '') {
     echo json_encode(['error' => 'Missing gamecode']);
     exit;
 }
+if (!preg_match('/^[A-Z0-9]{6}$/', $gamecode)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid gamecode format']);
+    exit;
+}
 require_once __DIR__ . '/db.php';
 $stmt = $pdo->prepare('SELECT data FROM collections WHERE gamecode = ? LIMIT 1');
 $stmt->execute([$gamecode]);

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -15,7 +15,7 @@ class ApiTest extends TestCase
         $pdo = new PDO($dsn);
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE collections (gamecode TEXT, data TEXT)');
-        $pdo->exec("INSERT INTO collections (gamecode, data) VALUES ('FEST123', '{\"name\":\"classic_party\"}')");
+        $pdo->exec("INSERT INTO collections (gamecode, data) VALUES ('FEST12', '{\"name\":\"classic_party\"}')");
         $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, content TEXT, created_at TEXT)');
         $pdo->exec("INSERT INTO posts (slug, title, content, created_at) VALUES ('hello', 'Hello', 'World', '2023-01-01')");
     }
@@ -29,7 +29,7 @@ class ApiTest extends TestCase
 
     public function testCollectionEndpointReturnsData(): void
     {
-        $code = 'parse_str("gamecode=FEST123", $_GET); include "' . __DIR__ . '/../public/api/collection.php";';
+        $code = 'parse_str("gamecode=FEST12", $_GET); include "' . __DIR__ . '/../public/api/collection.php";';
         $output = shell_exec('php -r ' . escapeshellarg($code));
         $this->assertSame('{"name":"classic_party"}', trim($output));
     }


### PR DESCRIPTION
## Summary
- enforce strict format validation for gamecode and slug in API endpoints
- clarify error responses for invalid formats
- adjust API tests to use valid codes

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ca52080dc8328a6eebab065ff27a7