### PR TITLE
Add structured article support for games and drinks

### DIFF
--- a/public/api/article.php
+++ b/public/api/article.php
@@ -12,7 +12,7 @@ if (!preg_match('/^[a-z0-9-]{1,64}$/', $slug)) {
     exit;
 }
 require_once __DIR__ . '/db.php';
-$stmt = $pdo->prepare('SELECT title, content, created_at FROM posts WHERE slug = ? LIMIT 1');
+$stmt = $pdo->prepare('SELECT title, type, content, requirements, ingredients, featured_image, created_at FROM posts WHERE slug = ? LIMIT 1');
 $stmt->execute([$slug]);
 $post = $stmt->fetch();
 if (!$post) {

--- a/public/api/articles.php
+++ b/public/api/articles.php
@@ -1,7 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once __DIR__ . '/db.php';
-$stmt = $pdo->query('SELECT id, slug, title, created_at FROM posts ORDER BY created_at DESC');
+$stmt = $pdo->query('SELECT id, slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC');
 $posts = $stmt->fetchAll();
 echo json_encode($posts);
 ?>

--- a/public/blog/index.php
+++ b/public/blog/index.php
@@ -1,6 +1,6 @@
 <?php
 require_once __DIR__ . '/../api/db.php';
-$stmt = $pdo->query('SELECT slug, title, created_at FROM posts ORDER BY created_at DESC');
+$stmt = $pdo->query('SELECT slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC');
 $posts = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
@@ -13,9 +13,17 @@ $posts = $stmt->fetchAll();
 </head>
 <body>
 <h1>Blogg</h1>
-<ul>
+<ul class="articles">
 <?php foreach ($posts as $post): ?>
-<li><a href="/blog/post.php?slug=<?php echo htmlspecialchars($post['slug']); ?>"><?php echo htmlspecialchars($post['title']); ?></a> <small><?php echo htmlspecialchars($post['created_at']); ?></small></li>
+<li>
+  <?php if (!empty($post['featured_image'])): ?>
+    <img src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
+  <?php endif; ?>
+  <a href="/blog/post.php?slug=<?php echo htmlspecialchars($post['slug']); ?>">
+    <?php echo htmlspecialchars($post['title']); ?>
+  </a>
+  <small><?php echo htmlspecialchars($post['type']); ?> | <?php echo htmlspecialchars($post['created_at']); ?></small>
+</li>
 <?php endforeach; ?>
 </ul>
 </body>

--- a/public/blog/post.php
+++ b/public/blog/post.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../api/db.php';
 $slug = $_GET['slug'] ?? '';
-$stmt = $pdo->prepare('SELECT title, content, created_at FROM posts WHERE slug = ? LIMIT 1');
+$stmt = $pdo->prepare('SELECT title, type, content, requirements, ingredients, featured_image, created_at FROM posts WHERE slug = ? LIMIT 1');
 $stmt->execute([$slug]);
 $post = $stmt->fetch();
 if (!$post) {
@@ -21,6 +21,25 @@ if (!$post) {
 <body>
 <article>
 <h1><?php echo htmlspecialchars($post['title']); ?></h1>
+<?php if (!empty($post['featured_image'])): ?>
+  <img src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
+<?php endif; ?>
+<?php if ($post['type'] === 'game' && !empty($post['requirements'])): ?>
+  <h2>What you need</h2>
+  <ul>
+  <?php foreach (explode("\n", $post['requirements']) as $item): ?>
+    <?php if (trim($item) !== ''): ?><li><?php echo htmlspecialchars(trim($item)); ?></li><?php endif; ?>
+  <?php endforeach; ?>
+  </ul>
+<?php endif; ?>
+<?php if ($post['type'] === 'drink' && !empty($post['ingredients'])): ?>
+  <h2>Recipe</h2>
+  <ul>
+  <?php foreach (explode("\n", $post['ingredients']) as $item): ?>
+    <?php if (trim($item) !== ''): ?><li><?php echo htmlspecialchars(trim($item)); ?></li><?php endif; ?>
+  <?php endforeach; ?>
+  </ul>
+<?php endif; ?>
 <div class="content">
 <?php echo nl2br(htmlspecialchars($post['content'])); ?>
 </div>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -3,7 +3,11 @@ CREATE TABLE IF NOT EXISTS posts (
   id INT AUTO_INCREMENT PRIMARY KEY,
   slug VARCHAR(100) NOT NULL UNIQUE,
   title VARCHAR(255) NOT NULL,
+  type VARCHAR(20) NOT NULL,
   content TEXT NOT NULL,
+  requirements TEXT NULL,
+  ingredients TEXT NULL,
+  featured_image VARCHAR(255) NULL,
   created_at DATETIME NOT NULL
 );
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -16,8 +16,8 @@ class ApiTest extends TestCase
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE collections (gamecode TEXT, data TEXT)');
         $pdo->exec("INSERT INTO collections (gamecode, data) VALUES ('FEST12', '{\"name\":\"classic_party\"}')");
-        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, content TEXT, created_at TEXT)');
-        $pdo->exec("INSERT INTO posts (slug, title, content, created_at) VALUES ('hello', 'Hello', 'World', '2023-01-01')");
+        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, type TEXT, content TEXT, requirements TEXT, ingredients TEXT, featured_image TEXT, created_at TEXT)');
+        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, created_at) VALUES ('hello', 'Hello', 'game', 'World', 'cards', NULL, 'image.png', '2023-01-01')");
     }
 
     protected function tearDown(): void
@@ -38,7 +38,8 @@ class ApiTest extends TestCase
     {
         $code = 'include "' . __DIR__ . '/../public/api/articles.php";';
         $output = shell_exec('php -r ' . escapeshellarg($code));
-        $this->assertStringContainsString('hello', $output);
+        $data = json_decode($output, true);
+        $this->assertEquals('game', $data[0]['type']);
     }
 
     public function testArticleEndpointReturnsArticle(): void
@@ -47,5 +48,8 @@ class ApiTest extends TestCase
         $output = shell_exec('php -r ' . escapeshellarg($code));
         $data = json_decode($output, true);
         $this->assertEquals('Hello', $data['title']);
+        $this->assertEquals('game', $data['type']);
+        $this->assertEquals('cards', $data['requirements']);
+        $this->assertEquals('image.png', $data['featured_image']);
     }
 }


### PR DESCRIPTION
## Summary
- support `type`, recipe/requirements, and featured images in article schema
- expose new fields via API endpoints and blog templates
- cover new article structure with tests

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ca9a46e7083288673719b3cef59ea