### PR TITLE
feat: add user authentication

### DIFF
--- a/public/admin/auth.php
+++ b/public/admin/auth.php
@@ -1,0 +1,20 @@
+<?php
+session_set_cookie_params([
+    'lifetime' => 3600,
+    'path' => '/admin',
+    'httponly' => true,
+    'samesite' => 'Strict'
+]);
+session_start();
+$requireLogin = $requireLogin ?? true;
+if ($requireLogin) {
+    if (empty($_SESSION['user_id'])) {
+        header('Location: index.php');
+        exit;
+    }
+    if (!empty($requireRole) && ($_SESSION['role'] ?? '') !== $requireRole) {
+        http_response_code(403);
+        exit('Access denied');
+    }
+}
+?>

--- a/public/admin/new_post.php
+++ b/public/admin/new_post.php
@@ -1,15 +1,5 @@
 <?php
-session_set_cookie_params([
-    'lifetime' => 3600,
-    'path' => '/admin',
-    'httponly' => true,
-    'samesite' => 'Strict'
-]);
-session_start();
-if (empty($_SESSION['logged_in'])) {
-    header('Location: index.php');
-    exit;
-}
+require_once 'auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }

--- a/public/admin/settings/index.php
+++ b/public/admin/settings/index.php
@@ -1,0 +1,14 @@
+<?php
+$requireRole = 'admin';
+require_once '../auth.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Settings</title>
+</head>
+<body>
+<h1>Settings</h1>
+</body>
+</html>

--- a/public/admin/users/index.php
+++ b/public/admin/users/index.php
@@ -1,0 +1,14 @@
+<?php
+$requireRole = 'admin';
+require_once '../auth.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Users</title>
+</head>
+<body>
+<h1>Users</h1>
+</body>
+</html>

--- a/public/api/auth.php
+++ b/public/api/auth.php
@@ -1,0 +1,30 @@
+<?php
+session_set_cookie_params([
+    'lifetime' => 3600,
+    'path' => '/admin',
+    'httponly' => true,
+    'samesite' => 'Strict'
+]);
+session_start();
+header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+require_once __DIR__ . '/db.php';
+$email = $_POST['email'] ?? '';
+$password = $_POST['password'] ?? '';
+$stmt = $pdo->prepare('SELECT id, password_hash, role FROM users WHERE email = ?');
+$stmt->execute([$email]);
+$user = $stmt->fetch();
+if ($user && password_verify($password, $user['password_hash'])) {
+    session_regenerate_id(true);
+    $_SESSION['user_id'] = $user['id'];
+    $_SESSION['role'] = $user['role'];
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    echo json_encode(['success' => true]);
+} else {
+    http_response_code(401);
+    echo json_encode(['error' => 'Invalid credentials']);
+}

--- a/sql/001_create_users_table.sql
+++ b/sql/001_create_users_table.sql
@@ -1,0 +1,7 @@
+-- Migration to create users table
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  role VARCHAR(50) NOT NULL
+);


### PR DESCRIPTION
## Summary
- add migration for `users` table
- create login API and admin auth helper
- gate admin settings and users pages to admins and update admin login/new-post pages

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688caf2906a0832880ab858612c177b4