### PR TITLE
Add admin user management with MFA controls

### DIFF
--- a/public/admin/users/create.php
+++ b/public/admin/users/create.php
@@ -1,0 +1,63 @@
+<?php
+$requireRole = 'admin';
+require_once '../auth.php';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+require_once __DIR__ . '/../../api/db.php';
+
+$roles = ['user', 'admin'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Invalid CSRF token';
+    } else {
+        $email = trim($_POST['email'] ?? '');
+        $password = $_POST['password'] ?? '';
+        $role = $_POST['role'] ?? 'user';
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $error = 'Invalid email';
+        } elseif (strlen($password) < 8) {
+            $error = 'Password must be at least 8 characters';
+        } elseif (!in_array($role, $roles, true)) {
+            $role = 'user';
+        } else {
+            $stmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE email = ?');
+            $stmt->execute([$email]);
+            if ($stmt->fetchColumn() > 0) {
+                $error = 'Email already exists';
+            } else {
+                $hash = password_hash($password, PASSWORD_DEFAULT);
+                $stmt = $pdo->prepare('INSERT INTO users (email, password_hash, role) VALUES (?, ?, ?)');
+                $stmt->execute([$email, $hash, $role]);
+                $message = 'User created';
+                $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+            }
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Create User</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Create User</h1>
+<?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<form method="post">
+<input type="email" name="email" placeholder="Email" value="<?php echo htmlspecialchars($_POST['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" />
+<input type="password" name="password" placeholder="Password" />
+<select name="role">
+    <option value="user"<?php if (($_POST['role'] ?? '') === 'user') echo ' selected'; ?>>User</option>
+    <option value="admin"<?php if (($_POST['role'] ?? '') === 'admin') echo ' selected'; ?>>Admin</option>
+</select>
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
+<button type="submit">Create</button>
+</form>
+<p><a href="index.php">Back to users</a></p>
+</body>
+</html>

--- a/public/admin/users/edit.php
+++ b/public/admin/users/edit.php
@@ -1,0 +1,82 @@
+<?php
+$requireRole = 'admin';
+require_once '../auth.php';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+require_once __DIR__ . '/../../api/db.php';
+
+$roles = ['user', 'admin'];
+$id = $_GET['id'] ?? null;
+if (!$id) {
+    exit('ID missing');
+}
+$stmt = $pdo->prepare('SELECT id, email, role, mfa_secret FROM users WHERE id = ?');
+$stmt->execute([$id]);
+$user = $stmt->fetch();
+if (!$user) {
+    exit('User not found');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Invalid CSRF token';
+    } else {
+        $email = trim($_POST['email'] ?? '');
+        $password = $_POST['password'] ?? '';
+        $role = $_POST['role'] ?? 'user';
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $error = 'Invalid email';
+        } elseif ($password !== '' && strlen($password) < 8) {
+            $error = 'Password must be at least 8 characters';
+        } elseif (!in_array($role, $roles, true)) {
+            $role = 'user';
+        } else {
+            $stmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE email = ? AND id != ?');
+            $stmt->execute([$email, $id]);
+            if ($stmt->fetchColumn() > 0) {
+                $error = 'Email already exists';
+            } else {
+                if ($password !== '') {
+                    $hash = password_hash($password, PASSWORD_DEFAULT);
+                    $stmt = $pdo->prepare('UPDATE users SET email = ?, password_hash = ?, role = ? WHERE id = ?');
+                    $stmt->execute([$email, $hash, $role, $id]);
+                } else {
+                    $stmt = $pdo->prepare('UPDATE users SET email = ?, role = ? WHERE id = ?');
+                    $stmt->execute([$email, $role, $id]);
+                }
+                $message = 'User updated';
+                $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+                $stmt = $pdo->prepare('SELECT id, email, role, mfa_secret FROM users WHERE id = ?');
+                $stmt->execute([$id]);
+                $user = $stmt->fetch();
+            }
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Edit User</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Edit User</h1>
+<?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<form method="post">
+<input type="email" name="email" value="<?php echo htmlspecialchars($user['email'], ENT_QUOTES, 'UTF-8'); ?>" />
+<input type="password" name="password" placeholder="New password" />
+<select name="role">
+    <option value="user"<?php if ($user['role'] === 'user') echo ' selected'; ?>>User</option>
+    <option value="admin"<?php if ($user['role'] === 'admin') echo ' selected'; ?>>Admin</option>
+</select>
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
+<button type="submit">Update</button>
+</form>
+<p>MFA: <?php echo $user['mfa_secret'] ? 'Enabled' : 'Disabled'; ?><?php if ($user['mfa_secret']): ?> (<a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a>)<?php endif; ?></p>
+<p><a href="index.php">Back to users</a></p>
+</body>
+</html>

--- a/public/admin/users/index.php
+++ b/public/admin/users/index.php
@@ -1,14 +1,33 @@
 <?php
 $requireRole = 'admin';
 require_once '../auth.php';
+require_once __DIR__ . '/../../api/db.php';
+
+$stmt = $pdo->query('SELECT id, email, role, mfa_secret FROM users ORDER BY email');
+$users = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
 <title>Users</title>
+<link rel="stylesheet" href="/styles/main.css" />
 </head>
 <body>
 <h1>Users</h1>
+<p><a href="create.php">Create user</a></p>
+<table>
+<thead><tr><th>Email</th><th>Role</th><th>MFA</th><th>Actions</th></tr></thead>
+<tbody>
+<?php foreach ($users as $user): ?>
+<tr>
+<td><?php echo htmlspecialchars($user['email'], ENT_QUOTES, 'UTF-8'); ?></td>
+<td><?php echo htmlspecialchars($user['role'], ENT_QUOTES, 'UTF-8'); ?></td>
+<td><?php echo $user['mfa_secret'] ? 'Enabled' : 'Disabled'; ?></td>
+<td><a href="edit.php?id=<?php echo $user['id']; ?>">Edit</a><?php if ($user['mfa_secret']): ?> | <a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a><?php endif; ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
 </body>
 </html>

--- a/public/admin/users/reset_mfa.php
+++ b/public/admin/users/reset_mfa.php
@@ -1,0 +1,52 @@
+<?php
+$requireRole = 'admin';
+require_once '../auth.php';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+require_once __DIR__ . '/../../api/db.php';
+
+$id = $_GET['id'] ?? null;
+if (!$id) {
+    exit('ID missing');
+}
+$stmt = $pdo->prepare('SELECT id, email FROM users WHERE id = ?');
+$stmt->execute([$id]);
+$user = $stmt->fetch();
+if (!$user) {
+    exit('User not found');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Invalid CSRF token';
+    } else {
+        $stmt = $pdo->prepare('UPDATE users SET mfa_secret = NULL WHERE id = ?');
+        $stmt->execute([$id]);
+        $message = 'MFA reset';
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Reset MFA</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Reset MFA</h1>
+<p>User: <?php echo htmlspecialchars($user['email'], ENT_QUOTES, 'UTF-8'); ?></p>
+<?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<?php if (empty($message)): ?>
+<form method="post">
+<p>Are you sure you want to reset MFA for this user?</p>
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
+<button type="submit">Reset MFA</button>
+</form>
+<?php endif; ?>
+<p><a href="index.php">Back to users</a></p>
+</body>
+</html>

--- a/sql/003_add_mfa_to_users.sql
+++ b/sql/003_add_mfa_to_users.sql
@@ -1,0 +1,2 @@
+-- Migration to add MFA secret column to users
+ALTER TABLE users ADD COLUMN mfa_secret VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
## Summary
- List users with role and MFA status in admin panel
- Allow admins to create and edit user accounts
- Support resetting a user's MFA secret

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cb93757588328b2746a48494e61a7