### PR TITLE
Add admin article management with type filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 
 # Node
 node_modules/
+.phpunit.result.cache

--- a/public/admin/articles/create.php
+++ b/public/admin/articles/create.php
@@ -1,0 +1,85 @@
+<?php
+require_once '../auth.php';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+require_once __DIR__ . '/../../api/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Ugyldig CSRF-token';
+    } else {
+        $title = trim($_POST['title'] ?? '');
+        $slug = trim($_POST['slug'] ?? '');
+        $type = $_POST['type'] ?? 'game';
+        if (!in_array($type, ['drink','game'], true)) {
+            $type = 'game';
+        }
+        $requirements = trim($_POST['requirements'] ?? '');
+        $ingredients = trim($_POST['ingredients'] ?? '');
+        $content = trim($_POST['content'] ?? '');
+        $featured_image = null;
+        if (!empty($_FILES['featured_image']['name']) && $_FILES['featured_image']['error'] === UPLOAD_ERR_OK) {
+            $uploadDir = __DIR__ . '/../../uploads/articles/';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+            $ext = pathinfo($_FILES['featured_image']['name'], PATHINFO_EXTENSION);
+            $filename = bin2hex(random_bytes(16));
+            if ($ext) {
+                $filename .= '.' . strtolower($ext);
+            }
+            $dest = $uploadDir . $filename;
+            if (move_uploaded_file($_FILES['featured_image']['tmp_name'], $dest)) {
+                $featured_image = '/uploads/articles/' . $filename;
+            }
+        }
+        if ($title && $slug && $content) {
+            if (!preg_match('/^[a-z0-9-]+$/', $slug)) {
+                $error = 'Slug kan kun inneholde små bokstaver, tall og bindestrek';
+            } else {
+                $check = $pdo->prepare('SELECT COUNT(*) FROM posts WHERE slug = ?');
+                $check->execute([$slug]);
+                if ($check->fetchColumn() > 0) {
+                    $error = 'Slug finnes allerede';
+                } else {
+                    $sql = 'INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, NOW())';
+                    $stmt = $pdo->prepare($sql);
+                    $stmt->execute([$slug, $title, $type, $content, $requirements, $ingredients, $featured_image]);
+                    $message = 'Lagret!';
+                    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+                }
+            }
+        } else {
+            $error = 'Alle felt må fylles';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Ny artikkel</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Ny artikkel</h1>
+<?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<form method="post" enctype="multipart/form-data">
+<input type="text" name="title" placeholder="Tittel" />
+<input type="text" name="slug" placeholder="slug" />
+<select name="type">
+    <option value="game">Spill</option>
+    <option value="drink">Drink</option>
+</select>
+<textarea name="requirements" placeholder="Krav"></textarea>
+<textarea name="ingredients" placeholder="Ingredienser"></textarea>
+<input type="file" name="featured_image" accept="image/*" />
+<textarea name="content" placeholder="Innhold"></textarea>
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
+<button type="submit">Lagre</button>
+</form>
+</body>
+</html>

--- a/public/admin/articles/delete.php
+++ b/public/admin/articles/delete.php
@@ -1,0 +1,48 @@
+<?php
+require_once '../auth.php';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+require_once __DIR__ . '/../../api/db.php';
+
+$id = $_GET['id'] ?? null;
+if (!$id) {
+    exit('ID mangler');
+}
+
+$stmt = $pdo->prepare('SELECT title FROM posts WHERE id = ?');
+$stmt->execute([$id]);
+$article = $stmt->fetch();
+if (!$article) {
+    exit('Artikkel ikke funnet');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Ugyldig CSRF-token';
+    } else {
+        $stmt = $pdo->prepare('DELETE FROM posts WHERE id = ?');
+        $stmt->execute([$id]);
+        header('Location: index.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Slett artikkel</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Slett artikkel</h1>
+<p>Er du sikker på at du vil slette "<?php echo htmlspecialchars($article['title'], ENT_QUOTES, 'UTF-8'); ?>"?</p>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<form method="post">
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
+<button type="submit">Ja, slett</button>
+<a href="index.php">Avbryt</a>
+</form>
+</body>
+</html>

--- a/public/admin/articles/edit.php
+++ b/public/admin/articles/edit.php
@@ -1,0 +1,100 @@
+<?php
+require_once '../auth.php';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+require_once __DIR__ . '/../../api/db.php';
+
+$id = $_GET['id'] ?? null;
+if (!$id) {
+    exit('ID mangler');
+}
+
+$stmt = $pdo->prepare('SELECT * FROM posts WHERE id = ?');
+$stmt->execute([$id]);
+$article = $stmt->fetch();
+if (!$article) {
+    exit('Artikkel ikke funnet');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Ugyldig CSRF-token';
+    } else {
+        $title = trim($_POST['title'] ?? '');
+        $slug = trim($_POST['slug'] ?? '');
+        $type = $_POST['type'] ?? 'game';
+        if (!in_array($type, ['drink','game'], true)) {
+            $type = 'game';
+        }
+        $requirements = trim($_POST['requirements'] ?? '');
+        $ingredients = trim($_POST['ingredients'] ?? '');
+        $content = trim($_POST['content'] ?? '');
+        $featured_image = $article['featured_image'];
+        if (!empty($_FILES['featured_image']['name']) && $_FILES['featured_image']['error'] === UPLOAD_ERR_OK) {
+            $uploadDir = __DIR__ . '/../../uploads/articles/';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+            $ext = pathinfo($_FILES['featured_image']['name'], PATHINFO_EXTENSION);
+            $filename = bin2hex(random_bytes(16));
+            if ($ext) {
+                $filename .= '.' . strtolower($ext);
+            }
+            $dest = $uploadDir . $filename;
+            if (move_uploaded_file($_FILES['featured_image']['tmp_name'], $dest)) {
+                $featured_image = '/uploads/articles/' . $filename;
+            }
+        }
+        if ($title && $slug && $content) {
+            if (!preg_match('/^[a-z0-9-]+$/', $slug)) {
+                $error = 'Slug kan kun inneholde små bokstaver, tall og bindestrek';
+            } else {
+                $check = $pdo->prepare('SELECT COUNT(*) FROM posts WHERE slug = ? AND id != ?');
+                $check->execute([$slug, $id]);
+                if ($check->fetchColumn() > 0) {
+                    $error = 'Slug finnes allerede';
+                } else {
+                    $sql = 'UPDATE posts SET slug = ?, title = ?, type = ?, content = ?, requirements = ?, ingredients = ?, featured_image = ? WHERE id = ?';
+                    $stmt = $pdo->prepare($sql);
+                    $stmt->execute([$slug, $title, $type, $content, $requirements, $ingredients, $featured_image, $id]);
+                    $message = 'Oppdatert!';
+                    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+                    $stmt = $pdo->prepare('SELECT * FROM posts WHERE id = ?');
+                    $stmt->execute([$id]);
+                    $article = $stmt->fetch();
+                }
+            }
+        } else {
+            $error = 'Alle felt må fylles';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Rediger artikkel</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Rediger artikkel</h1>
+<?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
+<?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
+<form method="post" enctype="multipart/form-data">
+<input type="text" name="title" placeholder="Tittel" value="<?php echo htmlspecialchars($article['title'], ENT_QUOTES, 'UTF-8'); ?>" />
+<input type="text" name="slug" placeholder="slug" value="<?php echo htmlspecialchars($article['slug'], ENT_QUOTES, 'UTF-8'); ?>" />
+<select name="type">
+    <option value="game"<?php if ($article['type'] === 'game') echo ' selected'; ?>>Spill</option>
+    <option value="drink"<?php if ($article['type'] === 'drink') echo ' selected'; ?>>Drink</option>
+</select>
+<textarea name="requirements" placeholder="Krav"><?php echo htmlspecialchars($article['requirements'], ENT_QUOTES, 'UTF-8'); ?></textarea>
+<textarea name="ingredients" placeholder="Ingredienser"><?php echo htmlspecialchars($article['ingredients'], ENT_QUOTES, 'UTF-8'); ?></textarea>
+<input type="file" name="featured_image" accept="image/*" />
+<textarea name="content" placeholder="Innhold"><?php echo htmlspecialchars($article['content'], ENT_QUOTES, 'UTF-8'); ?></textarea>
+<input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
+<button type="submit">Oppdater</button>
+</form>
+</body>
+</html>

--- a/public/admin/articles/index.php
+++ b/public/admin/articles/index.php
@@ -1,0 +1,80 @@
+<?php
+require_once '../auth.php';
+require_once __DIR__ . '/../../api/db.php';
+
+$perPage = 10;
+$page = max(1, (int)($_GET['page'] ?? 1));
+$search = trim($_GET['q'] ?? '');
+$type = $_GET['type'] ?? '';
+
+$params = [];
+$where = 'WHERE 1';
+if ($search !== '') {
+    $where .= ' AND (title LIKE ? OR slug LIKE ?)';
+    $params[] = "%$search%";
+    $params[] = "%$search%";
+}
+if ($type !== '') {
+    $where .= ' AND type = ?';
+    $params[] = $type;
+}
+
+$countStmt = $pdo->prepare("SELECT COUNT(*) FROM posts $where");
+$countStmt->execute($params);
+$total = (int)$countStmt->fetchColumn();
+$totalPages = max(1, (int)ceil($total / $perPage));
+$offset = ($page - 1) * $perPage;
+
+$paramsWithLimit = $params;
+$paramsWithLimit[] = $perPage;
+$paramsWithLimit[] = $offset;
+$stmt = $pdo->prepare("SELECT id, title, slug, type FROM posts $where ORDER BY created_at DESC LIMIT ? OFFSET ?");
+$stmt->execute($paramsWithLimit);
+$articles = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<title>Artikler</title>
+<link rel="stylesheet" href="/styles/main.css" />
+</head>
+<body>
+<h1>Artikler</h1>
+<p><a href="create.php">Ny artikkel</a></p>
+<form method="get" style="margin-bottom:1em;">
+<input type="text" name="q" placeholder="Søk" value="<?php echo htmlspecialchars($search, ENT_QUOTES, 'UTF-8'); ?>" />
+<select name="type">
+    <option value="">Alle typer</option>
+    <option value="drink"<?php if ($type === 'drink') echo ' selected'; ?>>Drink</option>
+    <option value="game"<?php if ($type === 'game') echo ' selected'; ?>>Spill</option>
+</select>
+<button type="submit">Søk</button>
+</form>
+<table>
+<thead><tr><th>Tittel</th><th>Type</th><th>Slug</th><th>Handlinger</th></tr></thead>
+<tbody>
+<?php foreach ($articles as $article): ?>
+<tr>
+<td><?php echo htmlspecialchars($article['title'], ENT_QUOTES, 'UTF-8'); ?></td>
+<td><?php echo htmlspecialchars($article['type'], ENT_QUOTES, 'UTF-8'); ?></td>
+<td><?php echo htmlspecialchars($article['slug'], ENT_QUOTES, 'UTF-8'); ?></td>
+<td>
+    <a href="edit.php?id=<?php echo $article['id']; ?>">Rediger</a>
+    <a href="delete.php?id=<?php echo $article['id']; ?>">Slett</a>
+</td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+<p>Side <?php echo $page; ?> av <?php echo $totalPages; ?></p>
+<div>
+<?php if ($page > 1): ?>
+<a href="?<?php echo http_build_query(['page' => $page - 1, 'q' => $search, 'type' => $type]); ?>">Forrige</a>
+<?php endif; ?>
+<?php if ($page < $totalPages): ?>
+<a href="?<?php echo http_build_query(['page' => $page + 1, 'q' => $search, 'type' => $type]); ?>">Neste</a>
+<?php endif; ?>
+</div>
+</body>
+</html>

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -2,7 +2,7 @@
 $requireLogin = false;
 require_once 'auth.php';
 if (!empty($_SESSION['user_id'])) {
-    header('Location: new_post.php');
+    header('Location: articles/index.php');
     exit;
 }
 ?>
@@ -27,7 +27,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     const formData = new FormData(e.target);
     const resp = await fetch('/api/auth.php', {method: 'POST', body: formData});
     if (resp.ok) {
-        window.location.href = 'new_post.php';
+        window.location.href = 'articles/index.php';
     } else {
         document.getElementById('error').textContent = 'Feil e-post eller passord';
     }

--- a/public/api/articles.php
+++ b/public/api/articles.php
@@ -1,7 +1,13 @@
 <?php
 header('Content-Type: application/json');
 require_once __DIR__ . '/db.php';
-$stmt = $pdo->query('SELECT id, slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC');
+$type = $_GET['type'] ?? '';
+if ($type !== '') {
+    $stmt = $pdo->prepare('SELECT id, slug, title, type, featured_image, created_at FROM posts WHERE type = ? ORDER BY created_at DESC');
+    $stmt->execute([$type]);
+} else {
+    $stmt = $pdo->query('SELECT id, slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC');
+}
 $posts = $stmt->fetchAll();
 echo json_encode($posts);
 ?>

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -18,6 +18,7 @@ class ApiTest extends TestCase
         $pdo->exec("INSERT INTO collections (gamecode, data) VALUES ('FEST12', '{\"name\":\"classic_party\"}')");
         $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, type TEXT, content TEXT, requirements TEXT, ingredients TEXT, featured_image TEXT, created_at TEXT)');
         $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, created_at) VALUES ('hello', 'Hello', 'game', 'World', 'cards', NULL, 'image.png', '2023-01-01')");
+        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, created_at) VALUES ('drink', 'Drink', 'drink', 'Cheers', NULL, 'vodka', NULL, '2023-01-02')");
         $pdo->exec('CREATE TABLE games (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, slug TEXT, visibility TEXT, featured_image TEXT, content TEXT, edit_token TEXT, token_expires_at TEXT)');
         $pdo->exec("INSERT INTO games (title, slug, visibility, featured_image, content) VALUES ('Public Game', 'public-game', 'public', 'pub.png', 'hi')");
         $pdo->exec("INSERT INTO games (title, slug, visibility, featured_image, content) VALUES ('Hidden Game', 'hidden-game', 'hidden', NULL, 'secret')");
@@ -43,7 +44,19 @@ class ApiTest extends TestCase
         $code = 'include "' . __DIR__ . '/../public/api/articles.php";';
         $output = shell_exec('php -r ' . escapeshellarg($code));
         $data = json_decode($output, true);
-        $this->assertEquals('game', $data[0]['type']);
+        $this->assertCount(2, $data);
+        $types = array_column($data, 'type');
+        $this->assertContains('game', $types);
+        $this->assertContains('drink', $types);
+    }
+
+    public function testArticlesEndpointCanFilterByType(): void
+    {
+        $code = 'parse_str("type=drink", $_GET); include "' . __DIR__ . '/../public/api/articles.php";';
+        $output = shell_exec('php -r ' . escapeshellarg($code));
+        $data = json_decode($output, true);
+        $this->assertCount(1, $data);
+        $this->assertEquals('drink', $data[0]['type']);
     }
 
     public function testArticleEndpointReturnsArticle(): void


### PR DESCRIPTION
## Summary
- add CRUD interface for articles with pagination and search in admin
- allow setting article type (drink or game) and manage images
- filter articles API by optional `type` query parameter

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cbb1053a88328ac661aad4bb02f7c