### PR TITLE
Add MFA support with TOTP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,8 @@
     },
     "scripts": {
         "test": "phpunit --colors=always"
+    },
+    "require": {
+        "sonata-project/google-authenticator": "^2.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,89 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c23f37f66ceb05fd480caba8880c601",
-    "packages": [],
+    "content-hash": "536cef113fcf6b35ba23c01eb71a9dc5",
+    "packages": [
+        {
+            "name": "sonata-project/google-authenticator",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sonata-project/GoogleAuthenticator.git",
+                "reference": "71a4189228f93a9662574dc8c65e77ef55061b59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sonata-project/GoogleAuthenticator/zipball/71a4189228f93a9662574dc8c65e77ef55061b59",
+                "reference": "71a4189228f93a9662574dc8c65e77ef55061b59",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^5.1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Authenticator\\": "src/",
+                    "Sonata\\GoogleAuthenticator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@gmail.com"
+                },
+                {
+                    "name": "Christian Stocker",
+                    "email": "me@chregu.tv"
+                },
+                {
+                    "name": "Andre DeMarre",
+                    "homepage": "http://www.devnetwork.net/viewtopic.php?f=50&t=94989"
+                }
+            ],
+            "description": "Library to integrate Google Authenticator into a PHP project",
+            "homepage": "https://github.com/sonata-project/GoogleAuthenticator",
+            "keywords": [
+                "google authenticator"
+            ],
+            "support": {
+                "issues": "https://github.com/sonata-project/GoogleAuthenticator/issues",
+                "source": "https://github.com/sonata-project/GoogleAuthenticator/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/VincentLanglet",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/core23",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/wbloszyk",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2021-02-15T19:23:18+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/public/admin/users/edit.php
+++ b/public/admin/users/edit.php
@@ -11,7 +11,7 @@ $id = $_GET['id'] ?? null;
 if (!$id) {
     exit('ID missing');
 }
-$stmt = $pdo->prepare('SELECT id, email, role, mfa_secret FROM users WHERE id = ?');
+$stmt = $pdo->prepare('SELECT id, email, role, mfa_enabled FROM users WHERE id = ?');
 $stmt->execute([$id]);
 $user = $stmt->fetch();
 if (!$user) {
@@ -47,7 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 $message = 'User updated';
                 $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-                $stmt = $pdo->prepare('SELECT id, email, role, mfa_secret FROM users WHERE id = ?');
+                $stmt = $pdo->prepare('SELECT id, email, role, mfa_enabled FROM users WHERE id = ?');
                 $stmt->execute([$id]);
                 $user = $stmt->fetch();
             }
@@ -76,7 +76,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Update</button>
 </form>
-<p>MFA: <?php echo $user['mfa_secret'] ? 'Enabled' : 'Disabled'; ?><?php if ($user['mfa_secret']): ?> (<a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a>)<?php endif; ?></p>
+<p>MFA: <?php echo $user['mfa_enabled'] ? 'Enabled' : 'Disabled'; ?><?php if ($user['mfa_enabled']): ?> (<a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a>)<?php endif; ?></p>
 <p><a href="index.php">Back to users</a></p>
 </body>
 </html>

--- a/public/admin/users/index.php
+++ b/public/admin/users/index.php
@@ -3,7 +3,7 @@ $requireRole = 'admin';
 require_once '../auth.php';
 require_once __DIR__ . '/../../api/db.php';
 
-$stmt = $pdo->query('SELECT id, email, role, mfa_secret FROM users ORDER BY email');
+$stmt = $pdo->query('SELECT id, email, role, mfa_enabled FROM users ORDER BY email');
 $users = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
@@ -23,8 +23,8 @@ $users = $stmt->fetchAll();
 <tr>
 <td><?php echo htmlspecialchars($user['email'], ENT_QUOTES, 'UTF-8'); ?></td>
 <td><?php echo htmlspecialchars($user['role'], ENT_QUOTES, 'UTF-8'); ?></td>
-<td><?php echo $user['mfa_secret'] ? 'Enabled' : 'Disabled'; ?></td>
-<td><a href="edit.php?id=<?php echo $user['id']; ?>">Edit</a><?php if ($user['mfa_secret']): ?> | <a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a><?php endif; ?></td>
+<td><?php echo $user['mfa_enabled'] ? 'Enabled' : 'Disabled'; ?></td>
+<td><a href="edit.php?id=<?php echo $user['id']; ?>">Edit</a><?php if ($user['mfa_enabled']): ?> | <a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a><?php endif; ?></td>
 </tr>
 <?php endforeach; ?>
 </tbody>

--- a/public/admin/users/reset_mfa.php
+++ b/public/admin/users/reset_mfa.php
@@ -21,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
         $error = 'Invalid CSRF token';
     } else {
-        $stmt = $pdo->prepare('UPDATE users SET mfa_secret = NULL WHERE id = ?');
+        $stmt = $pdo->prepare('UPDATE users SET mfa_secret = NULL, mfa_enabled = 0 WHERE id = ?');
         $stmt->execute([$id]);
         $message = 'MFA reset';
         $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/api/auth.php
+++ b/public/api/auth.php
@@ -12,13 +12,34 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(['error' => 'Method not allowed']);
     exit;
 }
+require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/db.php';
+use Sonata\GoogleAuthenticator\GoogleAuthenticator;
 $email = $_POST['email'] ?? '';
 $password = $_POST['password'] ?? '';
-$stmt = $pdo->prepare('SELECT id, password_hash, role FROM users WHERE email = ?');
+$stmt = $pdo->prepare('SELECT id, password_hash, role, mfa_secret, mfa_enabled FROM users WHERE email = ?');
 $stmt->execute([$email]);
 $user = $stmt->fetch();
 if ($user && password_verify($password, $user['password_hash'])) {
+    if (!empty($user['mfa_enabled'])) {
+        $totp = $_POST['totp'] ?? '';
+        $emailCode = $_POST['email_code'] ?? '';
+        $verified = false;
+        if ($totp !== '') {
+            $g = new GoogleAuthenticator();
+            $verified = $g->checkCode($user['mfa_secret'], $totp);
+        } elseif ($emailCode !== '') {
+            if (!empty($_SESSION['mfa_email_code']) && hash_equals($_SESSION['mfa_email_code'], $emailCode)) {
+                $verified = true;
+                unset($_SESSION['mfa_email_code']);
+            }
+        }
+        if (!$verified) {
+            http_response_code(401);
+            echo json_encode(['error' => 'MFA required']);
+            exit;
+        }
+    }
     session_regenerate_id(true);
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['role'] = $user['role'];

--- a/sql/003_add_mfa_to_users.sql
+++ b/sql/003_add_mfa_to_users.sql
@@ -1,2 +1,3 @@
--- Migration to add MFA secret column to users
+-- Migration to add MFA columns to users
 ALTER TABLE users ADD COLUMN mfa_secret VARCHAR(255) DEFAULT NULL;
+ALTER TABLE users ADD COLUMN mfa_enabled TINYINT(1) NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary
- add MFA columns to users table
- require TOTP or email code during login when MFA enabled
- allow admins to view and reset MFA status
- install sonata-project/google-authenticator for TOTP

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cc01b3f588328b2dae2298d34e099