### PR TITLE
docs: update documentation and add admin guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Velkommen til **GameNight** – en rask, offline-kapabel og sosialt engasjerende
 
 ## 🚀 Hva er GameNight?
 
-- En **Progressive Web App (PWA)** som kjører 100 % i nettleseren – ingen installasjon eller innlogging.
+- En **Progressive Web App (PWA)** som kjører 100 % i nettleseren for spillere – ingen installasjon eller innlogging kreves.
 - Spillere legger inn **navnene på deltakerne**, velger en spillmodus (collection), og appen viser **én tilfeldig utfordring av gangen**.
 - Fungerer **offline** takket være caching og lokal lagring.
-- Spillmoduser og blogginnhold kan hentes dynamisk via et lite **PHP-API** mot MySQL.
+- Spillmoduser, artikler og innstillinger administreres via et PHP-basert **admin-grensesnitt** med MySQL som database.
 
 ## ✅ Ferdige funksjoner
 - Spillmoduser lastes via GameCode og JSON-baserte filer
@@ -17,6 +17,12 @@ Velkommen til **GameNight** – en rask, offline-kapabel og sosialt engasjerende
 - Spillernavn lagres i `localStorage`, og placeholderen `{{player}}` erstattes automatisk
 - PWA-funksjoner med manifest og service worker gir offline-støtte
 - Sample-modus `FEST123` tilgjengelig for demo
+- **Administrasjonsverktøy**
+  - Innlogging med passord og TOTP-basert MFA
+  - Brukerhåndtering med oppretting, redigering og reset av MFA
+  - Spilladministrasjon med synlighet, bildeopplasting og eksterne redigeringstokens
+  - Artikkel- og bloggadministrasjon med filtrering på type
+  - Innstillinger med revisjonslogg
 
 ## 🚧 Gjenstående arbeid før lansering
 - Flere placeholders som `{{next}}` og `{{oldest}}`
@@ -24,12 +30,13 @@ Velkommen til **GameNight** – en rask, offline-kapabel og sosialt engasjerende
 - Editor for å lage og dele egne spillmoduser
 - Offline fallback ved nettverksfeil
 - Tidsstyrte temaer og flere visuelle temaer
-- Artikler og innhold for SEO
+- Flere artikler og innhold for SEO
 - Automatiserte tester og validering av collections
+- Forbedret admin-grensesnitt og tilgangskontroll
 
 ## 🛠️ Installasjon på server
 
-GameNight består av statiske filer og et lite PHP-API. Du kan hoste prosjektet på en vanlig Apache- eller Nginx-server.
+GameNight består av statiske filer, et PHP-API og et administrasjonsgrensesnitt. Du kan hoste prosjektet på en vanlig Apache- eller Nginx-server.
 
 1. **Klone repoet**
    ```bash
@@ -42,8 +49,8 @@ GameNight består av statiske filer og et lite PHP-API. Du kan hoste prosjektet 
    npm run build
    ```
 3. **Kopier `public/` til webserverens rot**
-   Dette er den prod-klare koden, inkludert `index.html`, service worker og API.
-4. **(Valgfritt) Sett opp database**
+   Dette er den prod-klare koden, inkludert `index.html`, service worker, API og admin-grensesnitt (`/admin`).
+4. **Sett opp database**
    - Importer `sql/schema.sql` i MySQL.
    - Konfigurer DB-tilkobling via miljøvariabler (`DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASS`) eller rediger `public/api/db.php`.
 5. **Aktiver HTTPS** for full PWA-støtte og sørg for at `manifest.json` og `service-worker.js` serveres med riktige MIME-typer.
@@ -76,6 +83,7 @@ GameNight/
 | `docs/content-strategy.md`   | Hvordan vi tenker rundt SEO, AdSense og artikler |
 | `docs/editor.md`             | Krav og mål for editor-verktøyet |
 | `docs/gpt-guidance.md`       | En forklaring for GPT/agenter som skal forstå prosjektet |
+| `docs/admin-interface.md`    | Detaljer om admin-grensesnittet |
 | `docs/changelog.md`          | Logg over hva som er bygget når |
 | `docs/languages.md`          | Hvordan språkutvidelse fungerer |
 | `docs/tests.md`              | Hva som må testes og hvordan |
@@ -86,8 +94,8 @@ GameNight/
 
 ## 🔒 Sikkerhet og personvern
 
-- Ingen innlogging; brukere lagrer ingenting online.
-- Spillmoduser lastes kun manuelt av prosjektets eier.
+- Spillere har ingen innlogging; all spillerdata lagres lokalt i nettleseren.
+- Admin-grensesnittet krever innlogging med MFA og logger endringer for revisjon.
 - Analyse skjer anonymt med Google Analytics.
 - Fullt i tråd med GDPR- og AdSense-retningslinjer.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,6 @@ Denne mappen inneholder all nødvendig informasjon for å forstå, videreutvikle
 ## Viktige dokumenter
 - `overview.md` – overordnet forklaring av prosjektet
 - `structure.md` – filstruktur og organisering
+- `features.md` – oversikt over ferdige og planlagte funksjoner
+- `admin-interface.md` – detaljer om admin-grensesnittet
 - `deployment.md` – hvordan installere prosjektet på en server

--- a/docs/admin-interface.md
+++ b/docs/admin-interface.md
@@ -1,0 +1,47 @@
+# Admin-grensesnitt
+
+Admin-panelet lar eiere og moderatorer administrere innholdet i GameNight. Det ligger under `/admin` og er bygget i PHP med enkle HTML-skjemaer og SweetAlert2 for tilbakemeldinger.
+
+## Funksjoner
+
+### Autentisering og sikkerhet
+- Innlogging med e-post og passord
+- TOTP-basert MFA eller engangskoder via e-post
+- CSRF-beskyttelse og strenge sesjonskapsler (`HttpOnly`, `SameSite=Strict`)
+
+### Brukere
+- Liste, opprettelse og redigering av brukere
+- Rollenivå: admin kan administrere andre brukere
+- Tilbakestilling av MFA
+
+### Spill
+- Opprett, rediger og slett spill
+- Synlighetsnivåer: `public`, `private`, `hidden`
+- Opplasting av fremhevet bilde
+- Generering av tidsbegrensede redigeringstoken for eksterne bidragsytere
+
+### Artikler
+- Opprett, rediger, søk og slett artikler
+- Filtrering på type (drink, game, ...)
+- Paginering av resultater
+
+### Innstillinger
+- Nøkkel/verdi-lagring av konfigurasjon
+- Audit-logg som viser hvem som endret hva
+- Sider for e-postserver og MFA-konfigurasjon
+
+## Brukervennlighet
+- Minimalistisk design med få distraksjoner
+- Navigasjon via lenker mellom seksjoner
+- Skjemaer er enkle og rett fram
+- Mangler dashboard og samlet navigasjonsmeny
+
+## Hva som mangler
+- WYSIWYG-editor for rik tekst
+- Søk og filtrering for spill og brukere
+- Role-based access utover `admin`
+- Bedre feilhåndtering og validering
+- Responsivt design og generell styling
+
+## Status
+De viktigste administrasjonsfunksjonene er implementert og fungerer, men grensesnittet er grunnleggende og kan forbedres med bedre UX, flere roller og rikere editorer.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@ Denne guiden beskriver hvordan du setter opp GameNight på en egen server.
 ## Krav
 - Apache eller Nginx med støtte for HTTPS
 - PHP 8 med PDO MySQL-utvidelse
-- MySQL 5.7+ (valgfritt, kun nødvendig for blogg og dynamiske spillmoduser)
+- MySQL 5.7+ for lagring av spill, artikler, brukere og innstillinger
 - Git for å hente koden
 
 ## Trinn
@@ -16,7 +16,7 @@ Denne guiden beskriver hvordan du setter opp GameNight på en egen server.
    ```
 2. **Kopier til webroot**
    - Last opp innholdet i `public/` til serverens document root.
-3. **Konfigurer database (valgfritt)**
+3. **Konfigurer database**
    - Importer `sql/schema.sql` i MySQL.
    - Sett miljøvariablene `DB_HOST`, `DB_NAME`, `DB_USER` og `DB_PASS`, eller rediger `public/api/db.php` direkte.
 4. **Sett admin-passord**

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -1,6 +1,7 @@
 # Dev-notater
 
-- TODO: Lage parser for challenges
-- Vurdere Alpine.js eller Svelte
-- Ønsker mørk modus
-- JSON-import fra editor
+- Lage parser og validering for challenges
+- Evaluere bruk av Alpine.js eller Svelte i frontend
+- Legge til mørk modus for spiller og admin
+- Fullføre editor og JSON-import
+- Forbedre admin-UI med søk og filtrering

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,14 +9,17 @@
 - Navn lagres i localStorage
 - Challenges støtter `{{player}}`-placeholder
 - Sample-modus `FEST123` tilgjengelig
-- Editor planlagt (ikke implementert)
-- Artikler for SEO planlagt
-- Visuell temastøtte planlagt (f.eks. glitch for "virus"-moduser)
+- **Admin-grensesnitt**
+  - Innlogging med passord og TOTP-basert MFA
+  - Spilladministrasjon med synlighet, bildeopplasting og eksterne tokens
+  - Artikkel- og bloggadministrasjon med typefiltrering
+  - Brukerhåndtering med MFA-reset
+  - Innstillinger med revisjonslogg
 
 ## 🛠 Planlagte funksjoner
 - Flere placeholders som `{{next}}`, `{{oldest}}`
 - UI-komponenter med animasjoner
-- Editor for spillmoduser
-- Deling av spillmoduser
+- Editor for spillmoduser og deling av moduser
 - Offline fallback ved nedkobling
-- Temastøtte etter dato
+- Temastøtte etter dato og flere visuelle temaer
+- Flere artikler og forbedret SEO

--- a/docs/gpt-guidance.md
+++ b/docs/gpt-guidance.md
@@ -1,6 +1,6 @@
 # GPT FORKLARING – TEKNISK BESKRIVELSE
 
-Dette prosjektet heter GameNight. Det er en PWA som kjører på Apache server uten backend eller database. Alle spillmoduser (collections) er JSON-filer som lastes manuelt opp av prosjektets eier (Jan Helge).
+Dette prosjektet heter GameNight. Frontenden er en PWA som kjører på Apache eller Nginx, mens dynamisk innhold administreres via et PHP-API og et eget admin-grensesnitt koblet til en MySQL-database. Spillmoduser (collections) kan fortsatt hentes som JSON-filer, men kan nå opprettes og vedlikeholdes gjennom admin-panelet.
 
 ## Status per 2025-05-07
 - GameCode brukes for å laste spillmodus
@@ -10,3 +10,4 @@ Dette prosjektet heter GameNight. Det er en PWA som kjører på Apache server ut
 - PWA-funksjonalitet er aktiv (manifest, service worker)
 - Sample-modus FEST123 demonstrerer flowen
 - Full `docs/`-struktur finnes
+- Admin-grensesnittet tilbyr innlogging med MFA og CRUD for spill, artikler, brukere og innstillinger

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,12 +1,13 @@
 # GameNight – Oversikt
 
-GameNight er en PWA-drikkespillplattform inspirert av Picolo. Appen fungerer offline, kjører på Apache, og bruker ingen backend eller database. Spillere legges inn manuelt, og spillmoduser lastes som JSON-filer fra server.
+GameNight er en PWA-drikkespillplattform inspirert av Picolo. Frontenden fungerer offline og kjører i nettleseren, mens et PHP-basert API og admin-grensesnitt mot en MySQL-database håndterer dynamisk innhold som spillmoduser, artikler og innstillinger.
 
 ## Status per 2025-05-07
 
-✅ Full dokumentasjon  
-✅ Spillmodus kan velges med GameCode  
-✅ Sample-modus `FEST123` tilgjengelig  
-✅ Spillere legges inn før start  
-✅ Placeholder `{{player}}` fungerer  
-✅ PWA-funksjoner implementert  
+✅ Full dokumentasjon
+✅ Spillmodus kan velges med GameCode
+✅ Sample-modus `FEST123` tilgjengelig
+✅ Spillere legges inn før start
+✅ Placeholder `{{player}}` fungerer
+✅ PWA-funksjoner implementert
+✅ Admin-grensesnitt med innlogging, MFA og CRUD for spill, artikler, brukere og innstillinger

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,18 +1,20 @@
 # Roadmap
 
-## MVP
+## MVP (ferdig)
 - Visning av spillmoduser og challenges
 - PWA offline
 
-## V1
-- Editor
-- Theming
+## V1 (pågående)
+- Admin-grensesnitt med bruker-, spill-, artikkel- og innstillingshåndtering ✅
 - Gamecode-søk
+- Grunnleggende SEO-artikler ✅
 
 ## V2
-- Artikler
-- SEO og AdSense
+- Editor for spillmoduser
+- Theming og tidsstyrte temaer
+- Deling av spillmoduser
 
 ## V3
+- Utvidet SEO og AdSense
 - Merch
 - Chromecast/casting

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -2,17 +2,20 @@
 
 ```
 GameNight/
-├── public/              # Innhold tilgjengelig for klienten (bilder, logoer, mockups)
-│   ├── logos/
-│   ├── mockups/
-│   └── challenges/      # Ikoner for spillutfordringer
-├── src/                 # All frontend-kode
+├── public/              # Prod-klar kode, API og admin
+│   ├── api/             # PHP-endepunkter
+│   ├── admin/           # Admin-grensesnitt
+│   ├── assets/, backgrounds/, ...
+│   └── challenges/, logos/, mockups/  # Statiske ressurser
+├── src/                 # Frontend-kildekode
 │   ├── index.html
 │   ├── main.js
 │   ├── styles/
 │   ├── components/
 │   └── data/            # Parsed collections fra JSON
+├── sql/                 # Databaseskjema og migrasjoner
 ├── docs/                # Dokumentasjon (denne mappen)
+├── tests/               # PHPUnit-tester
 ├── README.md
-└── .gitignore
+└── ...
 ```

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,7 +1,8 @@
 # Teknologistack
 
-- Vanilla JS
-- Apache hosting
-- JSON som datakilde
-- Ingen database
-- Lokal lagring (localStorage)
+- Frontend: Vite-bundlet **vanilla JavaScript** med PWA-støtte
+- Backend: **PHP 8** med MySQL-database og REST-aktig API
+- Admin-grensesnitt: PHP/JS med SweetAlert2 for dialoger
+- Testing: **Jest** for JS og **PHPUnit** for API
+- Hosting: Apache eller Nginx med HTTPS
+- Data lagres i MySQL og i `localStorage` for spillerstatistikk

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -4,7 +4,10 @@
 - Appen skal vise alle challenges én gang hver
 - Appen skal fungere uten nett etter første besøk
 - GameCode skal hente riktig collection
+- Admin-grensesnittet skal kreve innlogging og MFA
+- CRUD for spill, artikler og brukere skal fungere
 
 ## Potensiell automatisering (senere)
 - Test at collections er gyldige i henhold til schema
 - Test at editor ikke genererer ugyldig JSON
+- Test autentisering og rettigheter i admin-APIet


### PR DESCRIPTION
## Summary
- document new admin capabilities and security
- refresh project overview, tech stack, roadmap and tests docs
- add dedicated admin-interface guide

## Testing
- `npm test`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cc9e2439083289c8494433d1e1b2e