### PR TITLE
feat: add support for new challenge types

### DIFF
--- a/__tests__/collectionSchema.test.js
+++ b/__tests__/collectionSchema.test.js
@@ -8,10 +8,20 @@ const gameSchema = JSON.parse(fs.readFileSync(path.join('docs', 'game-schema.jso
 const ajv = new Ajv({ allErrors: true });
 ajv.addSchema(gameSchema, 'game-schema.json');
 const validate = ajv.compile(collectionSchema);
+const validateGame = ajv.compile(gameSchema);
 
 test('FEST123 collection matches schema', () => {
   const data = JSON.parse(fs.readFileSync('public/data/collections/FEST123.json', 'utf-8'));
   const valid = validate(data);
   if (!valid) console.error(validate.errors);
   expect(valid).toBe(true);
+});
+
+test('game schema accepts new challenge types', () => {
+  const base = { id: 'test', title: 'Test challenge' };
+  ['spillthetea', 'yayornay'].forEach(type => {
+    const valid = validateGame({ ...base, type });
+    if (!valid) console.error(validateGame.errors);
+    expect(valid).toBe(true);
+  });
 });

--- a/docs/game-schema.json
+++ b/docs/game-schema.json
@@ -4,7 +4,17 @@
   "type": "object",
   "properties": {
     "id": { "type": "string" },
-    "type": { "type": "string", "enum": ["never", "challenge", "truth", "custom"] },
+    "type": {
+      "type": "string",
+      "enum": [
+        "never",
+        "challenge",
+        "truth",
+        "custom",
+        "spillthetea",
+        "yayornay"
+      ]
+    },
     "title": { "type": "string" },
     "description": { "type": "string" },
     "tags": { "type": "array", "items": { "type": "string" } },

--- a/public/components/ChallengeCard.js
+++ b/public/components/ChallengeCard.js
@@ -3,6 +3,25 @@ export function showChallenge(collection) {
   const shownIds = new Set();
   const players = JSON.parse(localStorage.getItem('players') || '[]');
 
+  const typeAssets = {
+    challenge: {
+      background: '/backgrounds/challenge.jpg',
+      title: '/titles/challenge.png'
+    },
+    never: {
+      background: '/backgrounds/jegharaldri.jpg',
+      title: '/titles/jegharaldri.png'
+    },
+    spillthetea: {
+      background: '/backgrounds/spillthetea.jpg',
+      title: '/titles/spillthetea.png'
+    },
+    yayornay: {
+      background: '/backgrounds/yayornay.jpg',
+      title: '/titles/yayornay.png'
+    }
+  };
+
   function getNextChallenge() {
     const unused = collection.challenges.filter(c => !shownIds.has(c.id));
     if (unused.length === 0) {
@@ -23,14 +42,18 @@ export function showChallenge(collection) {
   }
 
   function renderChallenge(challenge) {
-    app.innerHTML = \`
+    const assets = typeAssets[challenge.type] || typeAssets.challenge;
+    document.body.style.backgroundImage = `url('${assets.background}')`;
+    app.innerHTML = `
       <div class="challenge-card">
-        <h3>\${replacePlaceholders(challenge.title)}</h3>
+        <img src="${assets.title}" alt="${challenge.type}" />
+        <h3>${replacePlaceholders(challenge.title)}</h3>
         <button id="nextBtn">Neste</button>
       </div>
-    \`;
+    `;
     document.getElementById('nextBtn').addEventListener('click', getNextChallenge);
   }
 
   getNextChallenge();
 }
+

--- a/src/components/ChallengeCard.js
+++ b/src/components/ChallengeCard.js
@@ -3,6 +3,25 @@ export function showChallenge(collection) {
   const shownIds = new Set();
   const players = JSON.parse(localStorage.getItem('players') || '[]');
 
+  const typeAssets = {
+    challenge: {
+      background: '/backgrounds/challenge.jpg',
+      title: '/titles/challenge.png'
+    },
+    never: {
+      background: '/backgrounds/jegharaldri.jpg',
+      title: '/titles/jegharaldri.png'
+    },
+    spillthetea: {
+      background: '/backgrounds/spillthetea.jpg',
+      title: '/titles/spillthetea.png'
+    },
+    yayornay: {
+      background: '/backgrounds/yayornay.jpg',
+      title: '/titles/yayornay.png'
+    }
+  };
+
   function getNextChallenge() {
     const unused = collection.challenges.filter(c => !shownIds.has(c.id));
     if (unused.length === 0) {
@@ -23,8 +42,11 @@ export function showChallenge(collection) {
   }
 
   function renderChallenge(challenge) {
+    const assets = typeAssets[challenge.type] || typeAssets.challenge;
+    document.body.style.backgroundImage = `url('${assets.background}')`;
     app.innerHTML = `
       <div class="challenge-card">
+        <img src="${assets.title}" alt="${challenge.type}" />
         <h3>${replacePlaceholders(challenge.title)}</h3>
         <button id="nextBtn">Neste</button>
       </div>
@@ -34,3 +56,4 @@ export function showChallenge(collection) {
 
   getNextChallenge();
 }
+


### PR DESCRIPTION
## Summary
- allow `spillthetea` and `yayornay` in game schema
- update challenge renderer for per-type backgrounds and titles
- expand tests to validate new challenge types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ccf48aee883288e58f0254964415f