### PR TITLE
feat: add validation and preview to collection editor

### DIFF
--- a/public/admin/collections/edit.php
+++ b/public/admin/collections/edit.php
@@ -75,6 +75,8 @@ $name = $data['name'] ?? '';
 $visibility = $data['visibility'] ?? 'public';
 $image = $data['image'] ?? '';
 $challenges = $data['challenges'] ?? [];
+$collectionSchemaJson = file_get_contents(__DIR__ . '/../../../docs/collection-schema.json');
+$gameSchemaJson = file_get_contents(__DIR__ . '/../../../docs/game-schema.json');
 ?>
 <!DOCTYPE html>
 <html lang="no">
@@ -82,6 +84,7 @@ $challenges = $data['challenges'] ?? [];
 <meta charset="UTF-8" />
 <title>Rediger collection</title>
 <link rel="stylesheet" href="/styles/main.css" />
+<style>.invalid{border:2px solid red;}</style>
 </head>
 <body>
 <h1>Rediger collection</h1>
@@ -89,6 +92,7 @@ $challenges = $data['challenges'] ?? [];
 <?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
 <form method="post" enctype="multipart/form-data">
 <input type="text" name="name" placeholder="Navn" value="<?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?>" />
+<input type="text" name="gamecode" placeholder="Gamecode" value="<?php echo htmlspecialchars($collection['gamecode'], ENT_QUOTES, 'UTF-8'); ?>" readonly />
 <select name="visibility">
     <option value="public"<?php if ($visibility === 'public') echo ' selected'; ?>>Synlig</option>
     <option value="private"<?php if ($visibility === 'private') echo ' selected'; ?>>Privat</option>
@@ -104,6 +108,10 @@ $challenges = $data['challenges'] ?? [];
 <?php endforeach; ?>
 </div>
 <button type="button" id="addChallenge">Legg til utfordring</button>
+<div id="previewContainer" style="margin-top:1em;">
+  <h2>Forhåndsvisning</h2>
+  <div id="previewApp"></div>
+</div>
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Oppdater</button>
 </form>
@@ -114,21 +122,82 @@ $challenges = $data['challenges'] ?? [];
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit" name="generate_token">Generer ekstern lenke</button>
 </form>
-<script>
-(function() {
-  const container = document.getElementById('challenges');
-  document.getElementById('addChallenge').addEventListener('click', () => addRow(''));
-  function addRow(value) {
-    const div = document.createElement('div');
-    div.className = 'challenge-row';
-    div.innerHTML = '<input type="text" name="challenges[]" value="' + value.replace(/"/g, '&quot;') + '" /> <button type="button" class="remove-challenge">Fjern</button>';
-    div.querySelector('.remove-challenge').addEventListener('click', () => div.remove());
-    container.appendChild(div);
+<script type="module">
+import Ajv from 'https://cdn.jsdelivr.net/npm/ajv@8/dist/ajv.esm.js';
+import { showChallenge } from '/components/ChallengeCard.js';
+
+const collectionSchema = <?php echo $collectionSchemaJson; ?>;
+const gameSchema = <?php echo $gameSchemaJson; ?>;
+
+const ajv = new Ajv({allErrors: true});
+ajv.addSchema(gameSchema, 'game-schema.json');
+const validate = ajv.compile(collectionSchema);
+
+const form = document.querySelector('form');
+const container = document.getElementById('challenges');
+const addBtn = document.getElementById('addChallenge');
+const submitBtn = form.querySelector('button[type="submit"]');
+const previewEl = document.getElementById('previewApp');
+const errorBox = document.createElement('div');
+errorBox.style.color = 'red';
+form.insertBefore(errorBox, form.firstChild);
+
+function addRow(value) {
+  const div = document.createElement('div');
+  div.className = 'challenge-row';
+  div.innerHTML = '<input type="text" name="challenges[]" value="' + value.replace(/"/g, '&quot;') + '"> <button type="button" class="remove-challenge">Fjern</button>';
+  div.querySelector('.remove-challenge').addEventListener('click', () => { div.remove(); update(); });
+  div.querySelector('input').addEventListener('input', update);
+  container.appendChild(div);
+}
+
+addBtn.addEventListener('click', () => { addRow(''); update(); });
+
+container.querySelectorAll('.challenge-row input').forEach(inp => inp.addEventListener('input', update));
+container.querySelectorAll('.remove-challenge').forEach(btn => btn.addEventListener('click', () => { btn.parentElement.remove(); update(); }));
+
+form.addEventListener('input', update);
+form.addEventListener('submit', e => { if (!update()) e.preventDefault(); });
+
+function buildData() {
+  const name = form.querySelector('input[name="name"]').value.trim();
+  const gamecode = form.querySelector('input[name="gamecode"]').value.trim();
+  const visibility = form.querySelector('select[name="visibility"]').value;
+  const challenges = [...form.querySelectorAll('input[name="challenges[]"]')].map((input, idx) => ({
+    id: String(idx + 1),
+    type: 'challenge',
+    title: input.value.trim()
+  })).filter(c => c.title !== '');
+  return { name, gamecode, public: visibility === 'public', challenges };
+}
+
+function update() {
+  const data = buildData();
+  const valid = validate(data);
+  errorBox.innerHTML = '';
+  form.querySelectorAll('.invalid').forEach(el => el.classList.remove('invalid'));
+  if (!valid) {
+    validate.errors.forEach(err => {
+      const path = err.instancePath.split('/');
+      if (path[1] === 'name') form.querySelector('input[name="name"]').classList.add('invalid');
+      if (path[1] === 'gamecode') form.querySelector('input[name="gamecode"]').classList.add('invalid');
+      if (path[1] === 'challenges' && path[2]) {
+        const index = parseInt(path[2], 10);
+        const inputs = form.querySelectorAll('input[name="challenges[]"]');
+        if (inputs[index]) inputs[index].classList.add('invalid');
+      }
+      errorBox.innerHTML += '<div>' + (err.instancePath || 'root') + ' ' + err.message + '</div>';
+    });
   }
-  container.querySelectorAll('.remove-challenge').forEach(btn => {
-    btn.addEventListener('click', () => btn.parentElement.remove());
-  });
-})();
+  submitBtn.disabled = !valid;
+  previewEl.innerHTML = '';
+  if (data.challenges.length) {
+    showChallenge(data, { containerId: 'previewApp', applyBackground: false, nextBtnId: 'previewNext' });
+  }
+  return valid;
+}
+
+update();
 </script>
 </body>
 </html>

--- a/public/components/ChallengeCard.js
+++ b/public/components/ChallengeCard.js
@@ -1,5 +1,11 @@
-export function showChallenge(collection) {
-  const app = document.getElementById('app');
+export function showChallenge(collection, opts = {}) {
+  const {
+    containerId = 'app',
+    nextBtnId = 'nextBtn',
+    applyBackground = true
+  } = opts;
+
+  const app = document.getElementById(containerId);
   const shownIds = new Set();
   const players = JSON.parse(localStorage.getItem('players') || '[]');
 
@@ -43,15 +49,17 @@ export function showChallenge(collection) {
 
   function renderChallenge(challenge) {
     const assets = typeAssets[challenge.type] || typeAssets.challenge;
-    document.body.style.backgroundImage = `url('${assets.background}')`;
+    if (applyBackground) {
+      document.body.style.backgroundImage = `url('${assets.background}')`;
+    }
     app.innerHTML = `
       <div class="challenge-card">
         <img src="${assets.title}" alt="${challenge.type}" />
         <h3>${replacePlaceholders(challenge.title)}</h3>
-        <button id="nextBtn">Neste</button>
+        <button id="${nextBtnId}">Neste</button>
       </div>
     `;
-    document.getElementById('nextBtn').addEventListener('click', getNextChallenge);
+    document.getElementById(nextBtnId).addEventListener('click', getNextChallenge);
   }
 
   getNextChallenge();

--- a/src/components/ChallengeCard.js
+++ b/src/components/ChallengeCard.js
@@ -1,5 +1,11 @@
-export function showChallenge(collection) {
-  const app = document.getElementById('app');
+export function showChallenge(collection, opts = {}) {
+  const {
+    containerId = 'app',
+    nextBtnId = 'nextBtn',
+    applyBackground = true
+  } = opts;
+
+  const app = document.getElementById(containerId);
   const shownIds = new Set();
   const players = JSON.parse(localStorage.getItem('players') || '[]');
 
@@ -43,15 +49,17 @@ export function showChallenge(collection) {
 
   function renderChallenge(challenge) {
     const assets = typeAssets[challenge.type] || typeAssets.challenge;
-    document.body.style.backgroundImage = `url('${assets.background}')`;
+    if (applyBackground) {
+      document.body.style.backgroundImage = `url('${assets.background}')`;
+    }
     app.innerHTML = `
       <div class="challenge-card">
         <img src="${assets.title}" alt="${challenge.type}" />
         <h3>${replacePlaceholders(challenge.title)}</h3>
-        <button id="nextBtn">Neste</button>
+        <button id="${nextBtnId}">Neste</button>
       </div>
     `;
-    document.getElementById('nextBtn').addEventListener('click', getNextChallenge);
+    document.getElementById(nextBtnId).addEventListener('click', getNextChallenge);
   }
 
   getNextChallenge();


### PR DESCRIPTION
## Summary
- preview challenges in admin editor using existing showChallenge component
- validate collection form on the client with AJV against schema
- expand showChallenge to support custom containers and optional background

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688ce12fbaf083288e4b47a9f612a3a9