### PR TITLE
Restrict articles API to public posts only

### DIFF
--- a/public/api/articles.php
+++ b/public/api/articles.php
@@ -1,13 +1,18 @@
 <?php
 header('Content-Type: application/json');
 require_once __DIR__ . '/db.php';
+
 $type = $_GET['type'] ?? '';
 if ($type !== '') {
-    $stmt = $pdo->prepare('SELECT id, slug, title, type, featured_image, created_at FROM posts WHERE type = ? ORDER BY created_at DESC');
+    $stmt = $pdo->prepare("SELECT id, slug, title, type, featured_image, created_at FROM posts WHERE visibility = 'public' AND type = ? ORDER BY created_at DESC");
     $stmt->execute([$type]);
 } else {
-    $stmt = $pdo->query('SELECT id, slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC');
+    $stmt = $pdo->query("SELECT id, slug, title, type, featured_image, created_at FROM posts WHERE visibility = 'public' ORDER BY created_at DESC");
 }
+
 $posts = $stmt->fetchAll();
+if (empty($posts)) {
+    http_response_code(404);
+}
 echo json_encode($posts);
 ?>

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -16,9 +16,9 @@ class ApiTest extends TestCase
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE collections (gamecode TEXT, data TEXT, edit_token TEXT, token_expires_at TEXT)');
         $pdo->exec("INSERT INTO collections (gamecode, data) VALUES ('FEST12', '{\"name\":\"classic_party\"}')");
-        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, type TEXT, content TEXT, requirements TEXT, ingredients TEXT, featured_image TEXT, created_at TEXT)');
-        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, created_at) VALUES ('hello', 'Hello', 'game', 'World', 'cards', NULL, 'image.png', '2023-01-01')");
-        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, created_at) VALUES ('drink', 'Drink', 'drink', 'Cheers', NULL, 'vodka', NULL, '2023-01-02')");
+        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, type TEXT, content TEXT, requirements TEXT, ingredients TEXT, featured_image TEXT, visibility TEXT, created_at TEXT)');
+        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, visibility, created_at) VALUES ('hello', 'Hello', 'game', 'World', 'cards', NULL, 'image.png', 'public', '2023-01-01')");
+        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, visibility, created_at) VALUES ('drink', 'Drink', 'drink', 'Cheers', NULL, 'vodka', NULL, 'public', '2023-01-02')");
         $pdo->exec('CREATE TABLE games (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, slug TEXT, visibility TEXT, featured_image TEXT, content TEXT, edit_token TEXT, token_expires_at TEXT)');
         $pdo->exec("INSERT INTO games (title, slug, visibility, featured_image, content) VALUES ('Public Game', 'public-game', 'public', 'pub.png', 'hi')");
         $pdo->exec("INSERT INTO games (title, slug, visibility, featured_image, content) VALUES ('Hidden Game', 'hidden-game', 'hidden', NULL, 'secret')");
@@ -57,6 +57,17 @@ class ApiTest extends TestCase
         $data = json_decode($output, true);
         $this->assertCount(1, $data);
         $this->assertEquals('drink', $data[0]['type']);
+    }
+
+    public function testArticlesEndpointReturns404WhenNoPublicMatches(): void
+    {
+        $code = 'parse_str("type=unknown", $_GET); include "' . __DIR__ . '/../public/api/articles.php"; echo http_response_code();';
+        $output = shell_exec('php -r ' . escapeshellarg($code));
+        $output = trim($output);
+        $status = (int) substr($output, -3);
+        $data = json_decode(substr($output, 0, -3), true);
+        $this->assertSame([], $data);
+        $this->assertSame(404, $status);
     }
 
     public function testArticleEndpointReturnsArticle(): void


### PR DESCRIPTION
## Summary
- filter articles API queries to `visibility='public'` and return 404 when none found
- add coverage for empty results and include visibility in test fixtures

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688ceb13f74c8328bbdee1b83369a41e