### PR TITLE
Add visibility controls for collections and cache public only

### DIFF
--- a/public/admin/collections/edit.php
+++ b/public/admin/collections/edit.php
@@ -72,14 +72,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         if ($name) {
             $data['name'] = $name;
-            $data['visibility'] = $visibility;
+            $data['public'] = ($visibility === 'public');
             $data['image'] = $image;
             $data['challenges'] = $challenges;
-            $stmt = $pdo->prepare('UPDATE collections SET data = ? WHERE id = ?');
-            $stmt->execute([json_encode($data, JSON_UNESCAPED_UNICODE), $id]);
+            $stmt = $pdo->prepare('UPDATE collections SET data = ?, visibility = ? WHERE id = ?');
+            $stmt->execute([json_encode($data, JSON_UNESCAPED_UNICODE), $visibility, $id]);
             $message = 'Oppdatert!';
             $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
             $collection['data'] = json_encode($data);
+            $collection['visibility'] = $visibility;
         } else {
             $error = 'Navn må fylles';
         }
@@ -88,7 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $data = json_decode($collection['data'], true) ?: [];
 $name = $data['name'] ?? '';
-$visibility = $data['visibility'] ?? 'public';
+$visibility = $collection['visibility'] ?? 'public';
 $image = $data['image'] ?? '';
 $challenges = $data['challenges'] ?? [];
 $collectionSchemaJson = file_get_contents(__DIR__ . '/../../../docs/collection-schema.json');

--- a/public/admin/collections/index.php
+++ b/public/admin/collections/index.php
@@ -2,13 +2,14 @@
 require_once '../auth.php';
 require_once __DIR__ . '/../../api/db.php';
 
-$stmt = $pdo->query('SELECT id, gamecode, data FROM collections ORDER BY id DESC');
+$stmt = $pdo->query('SELECT id, gamecode, visibility, data FROM collections ORDER BY id DESC');
 $collections = [];
 while ($row = $stmt->fetch()) {
     $data = json_decode($row['data'], true);
     $collections[] = [
         'id' => $row['id'],
         'gamecode' => $row['gamecode'],
+        'visibility' => $row['visibility'],
         'name' => $data['name'] ?? ''
     ];
 }
@@ -23,12 +24,13 @@ while ($row = $stmt->fetch()) {
 <body>
 <h1>Collections</h1>
 <table>
-<thead><tr><th>Navn</th><th>Gamecode</th><th>Handlinger</th></tr></thead>
+<thead><tr><th>Navn</th><th>Gamecode</th><th>Synlighet</th><th>Handlinger</th></tr></thead>
 <tbody>
 <?php foreach ($collections as $c): ?>
 <tr>
 <td><?php echo htmlspecialchars($c['name'], ENT_QUOTES, 'UTF-8'); ?></td>
 <td><?php echo htmlspecialchars($c['gamecode'], ENT_QUOTES, 'UTF-8'); ?></td>
+<td><?php echo htmlspecialchars($c['visibility'], ENT_QUOTES, 'UTF-8'); ?></td>
 <td><a href="edit.php?id=<?php echo $c['id']; ?>">Rediger</a></td>
 </tr>
 <?php endforeach; ?>

--- a/public/api/collection.php
+++ b/public/api/collection.php
@@ -12,7 +12,7 @@ if (!preg_match('/^[A-Z0-9]{6}$/', $gamecode)) {
     exit;
 }
 require_once __DIR__ . '/db.php';
-$stmt = $pdo->prepare('SELECT data FROM collections WHERE gamecode = ? LIMIT 1');
+$stmt = $pdo->prepare("SELECT data FROM collections WHERE gamecode = ? AND visibility = 'public' LIMIT 1");
 $stmt->execute([$gamecode]);
 $row = $stmt->fetch();
 if (!$row) {

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -39,6 +39,22 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+
+  if (url.pathname === '/api/collection.php') {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(cache =>
+        fetch(event.request).then(response => {
+          if (response.ok) {
+            cache.put(event.request, response.clone());
+          }
+          return response;
+        }).catch(() => cache.match(event.request))
+      )
+    );
+    return;
+  }
+
   if (event.request.mode === 'navigate') {
     event.respondWith(
       fetch(event.request).catch(() => caches.match('/index.html'))

--- a/sql/006_add_visibility_to_collections.sql
+++ b/sql/006_add_visibility_to_collections.sql
@@ -1,0 +1,3 @@
+-- Migration to add visibility to collections
+ALTER TABLE collections
+  ADD COLUMN visibility ENUM('public','private','hidden') NOT NULL DEFAULT 'public';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS games (
 CREATE TABLE IF NOT EXISTS collections (
   id INT AUTO_INCREMENT PRIMARY KEY,
   gamecode VARCHAR(20) NOT NULL UNIQUE,
+  visibility ENUM('public','private','hidden') NOT NULL DEFAULT 'public',
   data JSON NOT NULL,
   edit_token VARCHAR(64) DEFAULT NULL,
   token_expires_at DATETIME DEFAULT NULL


### PR DESCRIPTION
## Summary
- add `visibility` column to collections schema and new migration
- restrict `collection.php` API to public collections
- expose visibility in admin and update service worker to cache public collections only

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cf03ead4483288a6c24b00f3621fb