### PR TITLE
Skip service worker caching for admin routes

### DIFF
--- a/__tests__/serviceWorkerFetch.test.js
+++ b/__tests__/serviceWorkerFetch.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+
+describe('service worker fetch handling', () => {
+  it('bypasses cache for admin routes', async () => {
+    const listeners = {};
+    global.self = { addEventListener: (type, cb) => { listeners[type] = cb; } };
+    global.caches = { match: jest.fn(), open: jest.fn(), keys: jest.fn() };
+    global.fetch = jest.fn().mockResolvedValue('network');
+
+    await import('../public/service-worker.js');
+
+    const event = {
+      request: { url: 'https://example.com/admin/dashboard', mode: 'navigate' },
+      respondWith: jest.fn()
+    };
+
+    listeners.fetch(event);
+
+    expect(fetch).toHaveBeenCalledWith(event.request);
+    expect(caches.match).not.toHaveBeenCalled();
+    expect(event.respondWith).toHaveBeenCalled();
+  });
+});
+

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -41,6 +41,12 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
 
+  const networkOnlyPaths = ['/admin'];
+  if (networkOnlyPaths.some(path => url.pathname.startsWith(path))) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   if (url.pathname === '/api/collection.php') {
     event.respondWith(
       caches.open(CACHE_NAME).then(cache =>


### PR DESCRIPTION
## Summary
- Ensure service worker bypasses cache for `/admin` routes
- Add Jest test verifying admin requests always go to the network

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cf7c06600832886ecb1b44c0d1a8d