### PR TITLE
Paginate blog posts with lazy-loaded images

### DIFF
--- a/public/blog/index.php
+++ b/public/blog/index.php
@@ -1,7 +1,36 @@
 <?php
 require_once __DIR__ . '/../api/db.php';
-$stmt = $pdo->query('SELECT slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC');
+
+$page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+$limit = 10;
+$offset = ($page - 1) * $limit;
+
+$stmt = $pdo->prepare('SELECT slug, title, type, featured_image, created_at FROM posts ORDER BY created_at DESC LIMIT :limit OFFSET :offset');
+$stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+$stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+$stmt->execute();
 $posts = $stmt->fetchAll();
+
+$totalStmt = $pdo->query('SELECT COUNT(*) FROM posts');
+$totalPosts = (int) $totalStmt->fetchColumn();
+$totalPages = (int) ceil($totalPosts / $limit);
+
+if (isset($_GET['ajax'])) {
+    foreach ($posts as $post) {
+        ?>
+        <li>
+          <?php if (!empty($post['featured_image'])): ?>
+            <img loading="lazy" src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
+          <?php endif; ?>
+          <a href="/blog/post.php?slug=<?php echo htmlspecialchars($post['slug']); ?>">
+            <?php echo htmlspecialchars($post['title']); ?>
+          </a>
+          <small><?php echo htmlspecialchars($post['type']); ?> | <?php echo htmlspecialchars($post['created_at']); ?></small>
+        </li>
+        <?php
+    }
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html lang="no">
@@ -17,7 +46,7 @@ $posts = $stmt->fetchAll();
 <?php foreach ($posts as $post): ?>
 <li>
   <?php if (!empty($post['featured_image'])): ?>
-    <img src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
+    <img loading="lazy" src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
   <?php endif; ?>
   <a href="/blog/post.php?slug=<?php echo htmlspecialchars($post['slug']); ?>">
     <?php echo htmlspecialchars($post['title']); ?>
@@ -26,5 +55,40 @@ $posts = $stmt->fetchAll();
 </li>
 <?php endforeach; ?>
 </ul>
+<nav class="pagination">
+  <button id="prev" <?php if ($page <= 1) echo 'disabled'; ?>>Previous</button>
+  <span id="page-info">Page <?php echo $page; ?> of <?php echo $totalPages; ?></span>
+  <button id="next" <?php if ($page >= $totalPages) echo 'disabled'; ?>>Next</button>
+</nav>
+<script>
+const totalPages = <?php echo $totalPages; ?>;
+let currentPage = <?php echo $page; ?>;
+const prevBtn = document.getElementById('prev');
+const nextBtn = document.getElementById('next');
+
+function loadPage(page) {
+  fetch(`/blog/index.php?page=${page}&ajax=1`)
+    .then(res => res.text())
+    .then(html => {
+      document.querySelector('.articles').innerHTML = html;
+      currentPage = page;
+      prevBtn.disabled = currentPage <= 1;
+      nextBtn.disabled = currentPage >= totalPages;
+      document.getElementById('page-info').textContent = `Page ${currentPage} of ${totalPages}`;
+    });
+}
+
+prevBtn.addEventListener('click', () => {
+  if (currentPage > 1) {
+    loadPage(currentPage - 1);
+  }
+});
+
+nextBtn.addEventListener('click', () => {
+  if (currentPage < totalPages) {
+    loadPage(currentPage + 1);
+  }
+});
+</script>
 </body>
 </html>

--- a/public/blog/post.php
+++ b/public/blog/post.php
@@ -22,7 +22,7 @@ if (!$post) {
 <article>
 <h1><?php echo htmlspecialchars($post['title']); ?></h1>
 <?php if (!empty($post['featured_image'])): ?>
-  <img src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
+  <img loading="lazy" src="<?php echo htmlspecialchars($post['featured_image']); ?>" alt="" />
 <?php endif; ?>
 <?php if ($post['type'] === 'game' && !empty($post['requirements'])): ?>
   <h2>What you need</h2>


### PR DESCRIPTION
## Summary
- Paginate blog posts with limit/offset and add AJAX-driven next/previous controls
- Defer blog image loading with `loading="lazy"`

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cfb2d4e8c8328aa000d31f4b0858a