### PR TITLE
Add caching headers to API endpoints

### DIFF
--- a/docs/api-caching.md
+++ b/docs/api-caching.md
@@ -1,0 +1,11 @@
+# API Caching
+
+Public GET endpoints send caching headers to reduce bandwidth and improve performance.
+
+| Endpoint | Cache-Control | Validation |
+| --- | --- | --- |
+| `articles.php`, `article.php`, `games.php`, `game.php` (public games), `collection.php` | `public, max-age=3600` | `ETag` |
+
+Clients should cache responses for up to one hour and revalidate using the returned `ETag`.  On a match the server responds with `304 Not Modified` and no body.
+
+Administrative endpoints such as `auth.php` and `cleanup_tokens.php` include `Cache-Control: no-store` and must never be cached.

--- a/public/api/article.php
+++ b/public/api/article.php
@@ -20,5 +20,16 @@ if (!$post) {
     echo json_encode(['error' => 'Article not found']);
     exit;
 }
-echo json_encode($post);
+
+$response = json_encode($post);
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET') {
+    $etag = '"' . md5($response) . '"';
+    header('Cache-Control: public, max-age=3600');
+    header("ETag: $etag");
+    if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+        http_response_code(304);
+        exit;
+    }
+}
+echo $response;
 ?>

--- a/public/api/articles.php
+++ b/public/api/articles.php
@@ -14,5 +14,16 @@ $posts = $stmt->fetchAll();
 if (empty($posts)) {
     http_response_code(404);
 }
-echo json_encode($posts);
+
+$response = json_encode($posts);
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET') {
+    $etag = '"' . md5($response) . '"';
+    header('Cache-Control: public, max-age=3600');
+    header("ETag: $etag");
+    if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+        http_response_code(304);
+        exit;
+    }
+}
+echo $response;
 ?>

--- a/public/api/auth.php
+++ b/public/api/auth.php
@@ -7,6 +7,7 @@ session_set_cookie_params([
 ]);
 session_start();
 header('Content-Type: application/json');
+header('Cache-Control: no-store');
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
     echo json_encode(['error' => 'Method not allowed']);

--- a/public/api/cleanup_tokens.php
+++ b/public/api/cleanup_tokens.php
@@ -1,5 +1,6 @@
 <?php
 header('Content-Type: application/json');
+header('Cache-Control: no-store');
 require_once __DIR__ . '/db.php';
 
 $cleared = 0;

--- a/public/api/collection.php
+++ b/public/api/collection.php
@@ -20,5 +20,16 @@ if (!$row) {
     echo json_encode(['error' => 'Collection not found']);
     exit;
 }
-echo $row['data'];
+
+$response = $row['data'];
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET') {
+    $etag = '"' . md5($response) . '"';
+    header('Cache-Control: public, max-age=3600');
+    header("ETag: $etag");
+    if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+        http_response_code(304);
+        exit;
+    }
+}
+echo $response;
 ?>

--- a/public/api/game.php
+++ b/public/api/game.php
@@ -34,9 +34,23 @@ if ($game['visibility'] === 'private') {
     }
 }
 
-echo json_encode([
+$response = json_encode([
     'title' => $game['title'],
     'content' => $game['content'],
     'featured_image' => $game['featured_image']
 ]);
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET') {
+    if ($game['visibility'] === 'public') {
+        $etag = '"' . md5($response) . '"';
+        header('Cache-Control: public, max-age=3600');
+        header("ETag: $etag");
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+            http_response_code(304);
+            exit;
+        }
+    } else {
+        header('Cache-Control: no-store');
+    }
+}
+echo $response;
 ?>

--- a/public/api/games.php
+++ b/public/api/games.php
@@ -7,5 +7,15 @@ $stmt = $pdo->prepare("SELECT id, slug, title, featured_image FROM games WHERE v
 $stmt->execute();
 $games = $stmt->fetchAll();
 
-echo json_encode($games);
+$response = json_encode($games);
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET') {
+    $etag = '"' . md5($response) . '"';
+    header('Cache-Control: public, max-age=3600');
+    header("ETag: $etag");
+    if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+        http_response_code(304);
+        exit;
+    }
+}
+echo $response;
 ?>


### PR DESCRIPTION
## Summary
- enable `Cache-Control`/ETag on public API responses
- keep admin endpoints uncached
- document recommended API cache durations

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688cfd7de1308328920350ecee7b5d11