### PR TITLE
feat: use persistent PDO connections

### DIFF
--- a/public/api/db.php
+++ b/public/api/db.php
@@ -12,6 +12,7 @@ $options = [
     PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
     PDO::ATTR_EMULATE_PREPARES   => false,
+    PDO::ATTR_PERSISTENT         => true,
 ];
 
 try {


### PR DESCRIPTION
## Summary
- enable persistent PDO connections for API database helper

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688cff70e0c0832896621c95fe717773