### PR TITLE
feat: add unified admin layout with role-based navigation

### DIFF
--- a/public/admin/articles/create.php
+++ b/public/admin/articles/create.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../auth.php';
+require_once '../layout.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
@@ -55,15 +55,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
+
+$title = 'Ny artikkel';
+$page = 'articles';
+$breadcrumbs = [
+    ['url' => '/admin/articles/', 'label' => 'Artikler'],
+    ['label' => 'Ny']
+];
+$help = 'Opprett en ny artikkel.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="no">
-<head>
-<meta charset="UTF-8" />
-<title>Ny artikkel</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Ny artikkel</h1>
 <?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
 <?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
@@ -81,5 +82,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Lagre</button>
 </form>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/admin/articles/edit.php
+++ b/public/admin/articles/edit.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../auth.php';
+require_once '../layout.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
@@ -70,15 +70,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
+
+$title = 'Rediger artikkel';
+$page = 'articles';
+$breadcrumbs = [
+    ['url' => '/admin/articles/', 'label' => 'Artikler'],
+    ['label' => 'Rediger']
+];
+$help = 'Oppdater artikkeldetaljer.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="no">
-<head>
-<meta charset="UTF-8" />
-<title>Rediger artikkel</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Rediger artikkel</h1>
 <?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
 <?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
@@ -96,5 +97,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Oppdater</button>
 </form>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/admin/articles/index.php
+++ b/public/admin/articles/index.php
@@ -1,9 +1,9 @@
 <?php
-require_once '../auth.php';
+require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 
 $perPage = 10;
-$page = max(1, (int)($_GET['page'] ?? 1));
+$pageNum = max(1, (int)($_GET['page'] ?? 1));
 $search = trim($_GET['q'] ?? '');
 $type = $_GET['type'] ?? '';
 
@@ -23,7 +23,7 @@ $countStmt = $pdo->prepare("SELECT COUNT(*) FROM posts $where");
 $countStmt->execute($params);
 $total = (int)$countStmt->fetchColumn();
 $totalPages = max(1, (int)ceil($total / $perPage));
-$offset = ($page - 1) * $perPage;
+$offset = ($pageNum - 1) * $perPage;
 
 $paramsWithLimit = $params;
 $paramsWithLimit[] = $perPage;
@@ -31,17 +31,17 @@ $paramsWithLimit[] = $offset;
 $stmt = $pdo->prepare("SELECT id, title, slug, type FROM posts $where ORDER BY created_at DESC LIMIT ? OFFSET ?");
 $stmt->execute($paramsWithLimit);
 $articles = $stmt->fetchAll();
+
+$title = 'Artikler';
+$page = 'articles';
+$breadcrumbs = [['label' => 'Artikler']];
+$help = 'Administrer artikler. Søk, rediger eller slett poster.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="no">
-<head>
-<meta charset="UTF-8" />
-<title>Artikler</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Artikler</h1>
+<?php if (user_can(['admin','editor'])): ?>
 <p><a href="create.php">Ny artikkel</a></p>
+<?php endif; ?>
 <form method="get" style="margin-bottom:1em;">
 <input type="text" name="q" placeholder="Søk" value="<?php echo htmlspecialchars($search, ENT_QUOTES, 'UTF-8'); ?>" />
 <select name="type">
@@ -61,20 +61,21 @@ $articles = $stmt->fetchAll();
 <td><?php echo htmlspecialchars($article['slug'], ENT_QUOTES, 'UTF-8'); ?></td>
 <td>
     <a href="edit.php?id=<?php echo $article['id']; ?>">Rediger</a>
+    <?php if (user_can(['admin'])): ?>
     <a href="delete.php?id=<?php echo $article['id']; ?>">Slett</a>
+    <?php endif; ?>
 </td>
 </tr>
 <?php endforeach; ?>
 </tbody>
 </table>
-<p>Side <?php echo $page; ?> av <?php echo $totalPages; ?></p>
+<p>Side <?php echo $pageNum; ?> av <?php echo $totalPages; ?></p>
 <div>
-<?php if ($page > 1): ?>
-<a href="?<?php echo http_build_query(['page' => $page - 1, 'q' => $search, 'type' => $type]); ?>">Forrige</a>
+<?php if ($pageNum > 1): ?>
+<a href="?<?php echo http_build_query(['page' => $pageNum - 1, 'q' => $search, 'type' => $type]); ?>">Forrige</a>
 <?php endif; ?>
-<?php if ($page < $totalPages): ?>
-<a href="?<?php echo http_build_query(['page' => $page + 1, 'q' => $search, 'type' => $type]); ?>">Neste</a>
+<?php if ($pageNum < $totalPages): ?>
+<a href="?<?php echo http_build_query(['page' => $pageNum + 1, 'q' => $search, 'type' => $type]); ?>">Neste</a>
 <?php endif; ?>
 </div>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/admin/collections/index.php
+++ b/public/admin/collections/index.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../auth.php';
+require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 
 $stmt = $pdo->query('SELECT id, gamecode, visibility, data FROM collections ORDER BY id DESC');
@@ -13,15 +13,13 @@ while ($row = $stmt->fetch()) {
         'name' => $data['name'] ?? ''
     ];
 }
+
+$title = 'Collections';
+$page = 'collections';
+$breadcrumbs = [['label' => 'Samlinger']];
+$help = 'Oversikt over samlinger.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="no">
-<head>
-<meta charset="UTF-8" />
-<title>Collections</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Collections</h1>
 <table>
 <thead><tr><th>Navn</th><th>Gamecode</th><th>Synlighet</th><th>Handlinger</th></tr></thead>
@@ -36,5 +34,4 @@ while ($row = $stmt->fetch()) {
 <?php endforeach; ?>
 </tbody>
 </table>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/admin/games/index.php
+++ b/public/admin/games/index.php
@@ -1,21 +1,21 @@
 <?php
-require_once '../auth.php';
+require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 
 $stmt = $pdo->prepare('SELECT id, title, slug FROM games ORDER BY id DESC');
 $stmt->execute();
 $games = $stmt->fetchAll();
+
+$title = 'Games';
+$page = 'games';
+$breadcrumbs = [['label' => 'Spill']];
+$help = 'Administrer spill.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="no">
-<head>
-<meta charset="UTF-8" />
-<title>Games</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Games</h1>
+<?php if (user_can(['admin','editor'])): ?>
 <p><a href="create.php">Nytt spill</a></p>
+<?php endif; ?>
 <table>
 <thead><tr><th>Tittel</th><th>Slug</th><th>Handlinger</th></tr></thead>
 <tbody>
@@ -25,11 +25,12 @@ $games = $stmt->fetchAll();
 <td><?php echo htmlspecialchars($game['slug'], ENT_QUOTES, 'UTF-8'); ?></td>
 <td>
     <a href="edit.php?id=<?php echo $game['id']; ?>">Rediger</a>
+    <?php if (user_can(['admin'])): ?>
     <a href="delete.php?id=<?php echo $game['id']; ?>">Slett</a>
+    <?php endif; ?>
 </td>
 </tr>
 <?php endforeach; ?>
 </tbody>
 </table>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/admin/layout.php
+++ b/public/admin/layout.php
@@ -1,0 +1,67 @@
+<?php
+require_once __DIR__ . '/auth.php';
+
+function user_can(array $roles): bool {
+    return in_array($_SESSION['role'] ?? '', $roles, true);
+}
+
+function admin_header(array $options = []): void {
+    $title = $options['title'] ?? 'Admin';
+    $page = $options['page'] ?? '';
+    $breadcrumbs = $options['breadcrumbs'] ?? [];
+    $help = $options['help'] ?? '';
+    $role = $_SESSION['role'] ?? '';
+    ?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title><?php echo htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
+<link rel="stylesheet" href="/styles/admin.css" />
+</head>
+<body>
+<header class="admin-header">
+  <div class="logo"><a href="/admin/articles/">GameNight Admin</a></div>
+</header>
+<div class="admin-wrapper">
+<aside class="admin-sidebar">
+  <ul>
+    <?php if (user_can(['admin','editor'])): ?>
+    <li<?php if ($page === 'articles') echo ' class="active"'; ?>><a href="/admin/articles/">Artikler</a></li>
+    <li<?php if ($page === 'collections') echo ' class="active"'; ?>><a href="/admin/collections/">Samlinger</a></li>
+    <li<?php if ($page === 'games') echo ' class="active"'; ?>><a href="/admin/games/">Spill</a></li>
+    <?php endif; ?>
+    <?php if (user_can(['admin'])): ?>
+    <li<?php if ($page === 'users') echo ' class="active"'; ?>><a href="/admin/users/">Brukere</a></li>
+    <li<?php if ($page === 'settings') echo ' class="active"'; ?>><a href="/admin/settings/">Innstillinger</a></li>
+    <?php endif; ?>
+  </ul>
+</aside>
+<main class="admin-main">
+<?php if (!empty($breadcrumbs)): ?>
+<nav class="breadcrumbs">
+  <?php foreach ($breadcrumbs as $i => $crumb): ?>
+    <?php if ($i > 0): ?> / <?php endif; ?>
+    <?php if (!empty($crumb['url']) && $i < count($breadcrumbs) - 1): ?>
+      <a href="<?php echo $crumb['url']; ?>"><?php echo htmlspecialchars($crumb['label'], ENT_QUOTES, 'UTF-8'); ?></a>
+    <?php else: ?>
+      <span><?php echo htmlspecialchars($crumb['label'], ENT_QUOTES, 'UTF-8'); ?></span>
+    <?php endif; ?>
+  <?php endforeach; ?>
+</nav>
+<?php endif; ?>
+<?php if ($help): ?>
+<section class="help"><?php echo htmlspecialchars($help, ENT_QUOTES, 'UTF-8'); ?></section>
+<?php endif; ?>
+<?php
+}
+
+function admin_footer(): void {
+    ?>
+</main>
+</div>
+</body>
+</html>
+<?php
+}

--- a/public/admin/settings/index.php
+++ b/public/admin/settings/index.php
@@ -1,6 +1,6 @@
 <?php
 $requireRole = 'admin';
-require_once '../auth.php';
+require_once '../layout.php';
 
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
@@ -50,15 +50,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $stmt = $pdo->query('SELECT name, value FROM settings ORDER BY name');
 $settings = $stmt->fetchAll();
+
+$title = 'Settings';
+$page = 'settings';
+$breadcrumbs = [['label' => 'Innstillinger']];
+$help = 'Administrer applikasjonsinnstillinger.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8" />
-<title>Settings</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Settings</h1>
 <p><a href="mail.php">Mail Server</a> | <a href="mfa.php">MFA Options</a></p>
 <?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
@@ -82,6 +80,4 @@ $settings = $stmt->fetchAll();
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Save</button>
 </form>
-<p><a href="../index.php">Back to admin</a></p>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/admin/users/index.php
+++ b/public/admin/users/index.php
@@ -1,19 +1,17 @@
 <?php
 $requireRole = 'admin';
-require_once '../auth.php';
+require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 
 $stmt = $pdo->query('SELECT id, email, role, mfa_enabled FROM users ORDER BY email');
 $users = $stmt->fetchAll();
+
+$title = 'Users';
+$page = 'users';
+$breadcrumbs = [['label' => 'Brukere']];
+$help = 'Administrer brukerkontoer.';
+admin_header(compact('title','page','breadcrumbs','help'));
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8" />
-<title>Users</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
 <h1>Users</h1>
 <p><a href="create.php">Create user</a></p>
 <table>
@@ -29,5 +27,4 @@ $users = $stmt->fetchAll();
 <?php endforeach; ?>
 </tbody>
 </table>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/styles/admin.css
+++ b/public/styles/admin.css
@@ -1,0 +1,73 @@
+body {
+  margin: 0;
+  font-family: 'Segoe UI', sans-serif;
+  background: #f4f4f4;
+  color: #333;
+}
+.admin-header {
+  background: #222;
+  color: #fff;
+  padding: 1rem;
+}
+.admin-header .logo a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
+.admin-wrapper {
+  display: flex;
+  min-height: 100vh;
+}
+.admin-sidebar {
+  background: #333;
+  color: #fff;
+  width: 200px;
+  padding: 1rem;
+}
+.admin-sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.admin-sidebar li {
+  margin-bottom: 0.5rem;
+}
+.admin-sidebar a {
+  color: #fff;
+  text-decoration: none;
+}
+.admin-sidebar li.active a {
+  font-weight: bold;
+}
+.admin-main {
+  flex: 1;
+  padding: 1rem;
+}
+.breadcrumbs {
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+.breadcrumbs a {
+  color: #555;
+  text-decoration: none;
+}
+.help {
+  background: #eef;
+  border: 1px solid #ccd;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+@media (max-width: 768px) {
+  .admin-wrapper {
+    flex-direction: column;
+  }
+  .admin-sidebar {
+    width: 100%;
+    display: flex;
+    overflow-x: auto;
+  }
+  .admin-sidebar ul {
+    display: flex;
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add layout helper with header, sidebar, breadcrumbs and contextual help
- consolidate admin pages under shared layout and apply role-based controls
- style admin area with new responsive CSS

## Testing
- `php -l GameNight/public/admin/layout.php`
- `php -l GameNight/public/admin/articles/index.php`
- `php -l GameNight/public/admin/collections/index.php`
- `php -l GameNight/public/admin/games/index.php`
- `php -l GameNight/public/admin/settings/index.php`
- `php -l GameNight/public/admin/users/index.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688d04a368b4832892226877010cc3bd