### PR TITLE
Add SEO helper, dynamic sitemap, and configurable robots.txt

### DIFF
--- a/public/admin/settings/components.js
+++ b/public/admin/settings/components.js
@@ -48,3 +48,15 @@ export function selectBox(name, label, options = [], value = '') {
   wrapper.appendChild(labelEl);
   return { wrapper, input: select };
 }
+
+export function textArea(name, label, value = '') {
+  const wrapper = document.createElement('div');
+  const labelEl = document.createElement('label');
+  labelEl.textContent = label;
+  const textarea = document.createElement('textarea');
+  textarea.name = name;
+  textarea.value = value;
+  labelEl.appendChild(textarea);
+  wrapper.appendChild(labelEl);
+  return { wrapper, input: textarea };
+}

--- a/public/admin/settings/section.js
+++ b/public/admin/settings/section.js
@@ -1,4 +1,4 @@
-import { textInput, toggle, selectBox } from './components.js';
+import { textInput, toggle, selectBox, textArea } from './components.js';
 import { showToast } from '/components/Toast.js';
 
 export default function initSection(section, fields) {
@@ -20,6 +20,8 @@ export default function initSection(section, fields) {
           comp = toggle(field.name, field.label, value === '1');
         } else if (field.type === 'select') {
           comp = selectBox(field.name, field.label, field.options || [], value);
+        } else if (field.type === 'textarea') {
+          comp = textArea(field.name, field.label, value);
         }
         if (comp) {
           inputs[field.name] = comp.input;

--- a/public/admin/settings/seo.js
+++ b/public/admin/settings/seo.js
@@ -3,5 +3,6 @@ import initSection from './section.js';
 initSection('seo', [
   { type: 'text', name: 'seo_meta_description', label: 'Default Meta Description' },
   { type: 'text', name: 'seo_meta_keywords', label: 'Default Meta Keywords' },
-  { type: 'toggle', name: 'seo_indexing', label: 'Allow Search Engine Indexing' }
+  { type: 'toggle', name: 'seo_indexing', label: 'Allow Search Engine Indexing' },
+  { type: 'textarea', name: 'seo_robots_txt', label: 'robots.txt' }
 ]);

--- a/public/robots.php
+++ b/public/robots.php
@@ -1,0 +1,16 @@
+<?php
+header('Content-Type: text/plain');
+$default = "User-agent: *\nAllow: /\nSitemap: /sitemap.xml\n";
+$content = $default;
+try {
+    require_once __DIR__ . '/api/db.php';
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE name = ? LIMIT 1');
+    $stmt->execute(['seo_robots_txt']);
+    $val = $stmt->fetchColumn();
+    if ($val !== false && trim($val) !== '') {
+        $content = $val;
+    }
+} catch (Throwable $e) {
+    // ignore errors
+}
+echo $content;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,1 @@
+robots.php

--- a/public/seo.js
+++ b/public/seo.js
@@ -1,0 +1,43 @@
+export function setSEO({ title, description, url, image, type = 'website' } = {}) {
+  if (title) {
+    document.title = title;
+  }
+  if (description) {
+    setMeta('name', 'description', description);
+  }
+  if (url) {
+    setCanonical(url);
+  }
+  // Open Graph tags
+  if (title) setMeta('property', 'og:title', title);
+  if (description) setMeta('property', 'og:description', description);
+  if (url) setMeta('property', 'og:url', url);
+  setMeta('property', 'og:type', type);
+  if (image) setMeta('property', 'og:image', image);
+  // Twitter Card tags
+  setMeta('name', 'twitter:card', image ? 'summary_large_image' : 'summary');
+  if (title) setMeta('name', 'twitter:title', title);
+  if (description) setMeta('name', 'twitter:description', description);
+  if (image) setMeta('name', 'twitter:image', image);
+}
+
+function setMeta(attr, name, content) {
+  if (!content) return;
+  let tag = document.querySelector(`meta[${attr}="${name}"]`);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute(attr, name);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+}
+
+function setCanonical(url) {
+  let link = document.querySelector('link[rel="canonical"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.setAttribute('rel', 'canonical');
+    document.head.appendChild(link);
+  }
+  link.setAttribute('href', url);
+}

--- a/public/sitemap.php
+++ b/public/sitemap.php
@@ -1,0 +1,33 @@
+<?php
+header('Content-Type: application/xml');
+$scheme = $_SERVER['REQUEST_SCHEME'] ?? 'https';
+$host = $_SERVER['HTTP_HOST'] ?? 'example.com';
+$base = $scheme . '://' . $host;
+
+echo '<?xml version="1.0" encoding="UTF-8"?>';
+echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+// Blog posts from database
+try {
+    require_once __DIR__ . '/api/db.php';
+    $stmt = $pdo->query("SELECT slug, created_at FROM posts WHERE visibility = 'public'");
+    foreach ($stmt as $row) {
+        $loc = htmlspecialchars($base . '/blog/post.php?slug=' . urlencode($row['slug']), ENT_XML1);
+        $lastmod = htmlspecialchars(date('c', strtotime($row['created_at'])), ENT_XML1);
+        echo "<url><loc>{$loc}</loc><lastmod>{$lastmod}</lastmod></url>";
+    }
+} catch (Throwable $e) {
+    // ignore database errors
+}
+
+// Collections from JSON files
+foreach (glob(__DIR__ . '/data/collections/*.json') as $file) {
+    $json = json_decode(file_get_contents($file), true);
+    if (!is_array($json) || !($json['public'] ?? false)) continue;
+    $name = basename($file);
+    $loc = htmlspecialchars($base . '/data/collections/' . rawurlencode($name), ENT_XML1);
+    $lastmod = htmlspecialchars(date('c', filemtime($file)), ENT_XML1);
+    echo "<url><loc>{$loc}</loc><lastmod>{$lastmod}</lastmod></url>";
+}
+
+echo '</urlset>';

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,1 @@
+sitemap.php

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,9 @@
 import { renderPlayerInput } from './components/PlayerInput.js';
 import { registerServiceWorker } from './registerServiceWorker.js';
+import { setSEO } from './seo.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   renderPlayerInput();
   registerServiceWorker();
+  setSEO({ title: 'GameNight', url: window.location.href });
 });

--- a/src/seo.js
+++ b/src/seo.js
@@ -1,0 +1,43 @@
+export function setSEO({ title, description, url, image, type = 'website' } = {}) {
+  if (title) {
+    document.title = title;
+  }
+  if (description) {
+    setMeta('name', 'description', description);
+  }
+  if (url) {
+    setCanonical(url);
+  }
+  // Open Graph tags
+  if (title) setMeta('property', 'og:title', title);
+  if (description) setMeta('property', 'og:description', description);
+  if (url) setMeta('property', 'og:url', url);
+  setMeta('property', 'og:type', type);
+  if (image) setMeta('property', 'og:image', image);
+  // Twitter Card tags
+  setMeta('name', 'twitter:card', image ? 'summary_large_image' : 'summary');
+  if (title) setMeta('name', 'twitter:title', title);
+  if (description) setMeta('name', 'twitter:description', description);
+  if (image) setMeta('name', 'twitter:image', image);
+}
+
+function setMeta(attr, name, content) {
+  if (!content) return;
+  let tag = document.querySelector(`meta[${attr}="${name}"]`);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute(attr, name);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+}
+
+function setCanonical(url) {
+  let link = document.querySelector('link[rel="canonical"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.setAttribute('rel', 'canonical');
+    document.head.appendChild(link);
+  }
+  link.setAttribute('href', url);
+}

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -1,0 +1,46 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class SitemapTest extends TestCase
+{
+    private string $dbFile;
+
+    protected function setUp(): void
+    {
+        $this->dbFile = tempnam(sys_get_temp_dir(), 'db');
+        $dsn = 'sqlite:' . $this->dbFile;
+        putenv('DB_DSN=' . $dsn);
+        $pdo = new PDO($dsn);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, type TEXT, content TEXT, requirements TEXT, ingredients TEXT, featured_image TEXT, visibility TEXT, created_at TEXT)');
+        $pdo->exec("INSERT INTO posts (slug, title, type, content, requirements, ingredients, featured_image, visibility, created_at) VALUES ('hello', 'Hello', 'game', 'World', 'cards', NULL, 'image.png', 'public', '2023-01-01')");
+        $pdo->exec('CREATE TABLE settings (name TEXT, value TEXT)');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbFile)) {
+            unlink($this->dbFile);
+        }
+    }
+
+    public function testSitemapIncludesPostsAndCollections(): void
+    {
+        $code = 'include "' . __DIR__ . '/../public/sitemap.php";';
+        $output = shell_exec('php -r ' . escapeshellarg($code));
+        $this->assertStringContainsString('<loc>https://example.com/blog/post.php?slug=hello</loc>', $output);
+        $this->assertStringContainsString('/data/collections/FEST123.json', $output);
+    }
+
+    public function testRobotsTxtDefaultAndOverride(): void
+    {
+        $code = 'include "' . __DIR__ . '/../public/robots.php";';
+        $output = shell_exec('php -r ' . escapeshellarg($code));
+        $this->assertStringContainsString('Sitemap: /sitemap.xml', $output);
+
+        $pdo = new PDO('sqlite:' . $this->dbFile);
+        $pdo->exec("INSERT INTO settings (name, value) VALUES ('seo_robots_txt', 'User-agent: *\nDisallow: /secret')");
+        $output = shell_exec('php -r ' . escapeshellarg($code));
+        $this->assertStringContainsString('Disallow: /secret', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable SEO helper to manage title and meta tags
- generate sitemap.xml from blog posts and collection data
- expose robots.txt with admin override and textarea support in settings

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688d0c2ef2308328844b91fd383de20c