### PR TITLE
feat: add search engine verification tokens

### DIFF
--- a/public/admin/settings/seo.js
+++ b/public/admin/settings/seo.js
@@ -3,6 +3,8 @@ import initSection from './section.js';
 initSection('seo', [
   { type: 'text', name: 'seo_meta_description', label: 'Default Meta Description' },
   { type: 'text', name: 'seo_meta_keywords', label: 'Default Meta Keywords' },
+  { type: 'text', name: 'seo_google_verification', label: 'Google Verification Token' },
+  { type: 'text', name: 'seo_bing_verification', label: 'Bing Verification Token' },
   { type: 'toggle', name: 'seo_indexing', label: 'Allow Search Engine Indexing' },
   { type: 'textarea', name: 'seo_robots_txt', label: 'robots.txt' }
 ]);

--- a/public/admin/settings/seo.php
+++ b/public/admin/settings/seo.php
@@ -12,6 +12,12 @@ $help = 'Search engine optimization settings.';
 admin_header(compact('title', 'page', 'breadcrumbs', 'help'));
 ?>
 <h1>SEO Settings</h1>
+<p>Verify your site ownership with search engines:</p>
+<ol>
+    <li>Add your domain in <a href="https://search.google.com/search-console" target="_blank" rel="noopener">Google Search Console</a>.</li>
+    <li>Add your domain in <a href="https://www.bing.com/webmasters/" target="_blank" rel="noopener">Bing Webmaster Tools</a>.</li>
+    <li>Select HTML tag verification and paste the provided tokens below.</li>
+</ol>
 <div id="settings-form"></div>
 <script type="module" src="./seo.js"></script>
 <?php admin_footer(); ?>

--- a/public/blog/index.php
+++ b/public/blog/index.php
@@ -39,6 +39,7 @@ if (isset($_GET['ajax'])) {
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>GameNight Blogg</title>
 <link rel="stylesheet" href="/styles/main.css" />
+<?php include __DIR__ . '/../seo_verification.php'; ?>
 </head>
 <body>
 <h1>Blogg</h1>

--- a/public/blog/post.php
+++ b/public/blog/post.php
@@ -17,6 +17,7 @@ if (!$post) {
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title><?php echo htmlspecialchars($post['title']); ?></title>
 <link rel="stylesheet" href="/styles/main.css" />
+<?php include __DIR__ . '/../seo_verification.php'; ?>
 </head>
 <body>
 <article>

--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,7 @@
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="./styles/main.css">
   <title>GameNight</title>
+  <?php include __DIR__ . '/seo_verification.php'; ?>
 </head>
 <body>
   <div id="app">

--- a/public/seo_verification.php
+++ b/public/seo_verification.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/api/db.php';
+
+$tokens = [];
+$stmt = $pdo->prepare('SELECT name, value FROM settings WHERE name IN (?, ?)');
+$stmt->execute(['seo_google_verification', 'seo_bing_verification']);
+foreach ($stmt as $row) {
+    $tokens[$row['name']] = $row['value'];
+}
+
+$google = trim($tokens['seo_google_verification'] ?? '');
+$bing = trim($tokens['seo_bing_verification'] ?? '');
+
+if ($google !== '') {
+    echo '<meta name="google-site-verification" content="' . htmlspecialchars($google, ENT_QUOTES) . '">' . PHP_EOL;
+}
+if ($bing !== '') {
+    echo '<meta name="msvalidate.01" content="' . htmlspecialchars($bing, ENT_QUOTES) . '">' . PHP_EOL;
+}
+?>


### PR DESCRIPTION
## Summary
- add Google and Bing site verification token settings
- output verification meta tags on public pages
- guide admins through search console setup

## Testing
- `npm test`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688d0e99bf88832885c51c53d82cbe6b