### PR TITLE
Implement role-based roles and admin gating

### DIFF
--- a/public/admin/articles/create.php
+++ b/public/admin/articles/create.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../layout.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/articles/delete.php
+++ b/public/admin/articles/delete.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = 'admin';
 require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/articles/edit.php
+++ b/public/admin/articles/edit.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../layout.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/articles/index.php
+++ b/public/admin/articles/index.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 

--- a/public/admin/audit_logs/index.php
+++ b/public/admin/audit_logs/index.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = 'admin';
 require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 

--- a/public/admin/auth.php
+++ b/public/admin/auth.php
@@ -12,9 +12,12 @@ if ($requireLogin) {
         header('Location: index.php');
         exit;
     }
-    if (!empty($requireRole) && ($_SESSION['role'] ?? '') !== $requireRole) {
-        http_response_code(403);
-        exit('Access denied');
+    if (!empty($requireRole)) {
+        $roles = is_array($requireRole) ? $requireRole : [$requireRole];
+        if (!in_array($_SESSION['role'] ?? '', $roles, true)) {
+            http_response_code(403);
+            exit('Access denied');
+        }
     }
 }
 ?>

--- a/public/admin/collections/edit.php
+++ b/public/admin/collections/edit.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/collections/index.php
+++ b/public/admin/collections/index.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 

--- a/public/admin/games/create.php
+++ b/public/admin/games/create.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/games/delete.php
+++ b/public/admin/games/delete.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = 'admin';
 require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/games/edit.php
+++ b/public/admin/games/edit.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/games/index.php
+++ b/public/admin/games/index.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once '../layout.php';
 require_once __DIR__ . '/../../api/db.php';
 

--- a/public/admin/new_post.php
+++ b/public/admin/new_post.php
@@ -1,4 +1,5 @@
 <?php
+$requireRole = ['admin','editor'];
 require_once 'auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/public/admin/users/create.php
+++ b/public/admin/users/create.php
@@ -6,7 +6,7 @@ if (empty($_SESSION['csrf_token'])) {
 }
 require_once __DIR__ . '/../../api/db.php';
 
-$roles = ['user', 'admin'];
+$roles = ['viewer', 'editor', 'admin'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
@@ -14,13 +14,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
-        $role = $_POST['role'] ?? 'user';
+        $role = $_POST['role'] ?? 'viewer';
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $error = 'Invalid email';
         } elseif (strlen($password) < 8) {
             $error = 'Password must be at least 8 characters';
         } elseif (!in_array($role, $roles, true)) {
-            $role = 'user';
+            $role = 'viewer';
         } else {
             $stmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE email = ?');
             $stmt->execute([$email]);
@@ -52,7 +52,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="email" name="email" placeholder="Email" value="<?php echo htmlspecialchars($_POST['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" />
 <input type="password" name="password" placeholder="Password" />
 <select name="role">
-    <option value="user"<?php if (($_POST['role'] ?? '') === 'user') echo ' selected'; ?>>User</option>
+    <option value="viewer"<?php if (($_POST['role'] ?? '') === 'viewer') echo ' selected'; ?>>Viewer</option>
+    <option value="editor"<?php if (($_POST['role'] ?? '') === 'editor') echo ' selected'; ?>>Editor</option>
     <option value="admin"<?php if (($_POST['role'] ?? '') === 'admin') echo ' selected'; ?>>Admin</option>
 </select>
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />

--- a/public/admin/users/edit.php
+++ b/public/admin/users/edit.php
@@ -6,7 +6,7 @@ if (empty($_SESSION['csrf_token'])) {
 }
 require_once __DIR__ . '/../../api/db.php';
 
-$roles = ['user', 'admin'];
+$roles = ['viewer', 'editor', 'admin'];
 $id = $_GET['id'] ?? null;
 if (!$id) {
     exit('ID missing');
@@ -24,13 +24,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
-        $role = $_POST['role'] ?? 'user';
+        $role = $_POST['role'] ?? 'viewer';
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $error = 'Invalid email';
         } elseif ($password !== '' && strlen($password) < 8) {
             $error = 'Password must be at least 8 characters';
         } elseif (!in_array($role, $roles, true)) {
-            $role = 'user';
+            $role = 'viewer';
         } else {
             $stmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE email = ? AND id != ?');
             $stmt->execute([$email, $id]);
@@ -70,7 +70,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="email" name="email" value="<?php echo htmlspecialchars($user['email'], ENT_QUOTES, 'UTF-8'); ?>" />
 <input type="password" name="password" placeholder="New password" />
 <select name="role">
-    <option value="user"<?php if ($user['role'] === 'user') echo ' selected'; ?>>User</option>
+    <option value="viewer"<?php if ($user['role'] === 'viewer') echo ' selected'; ?>>Viewer</option>
+    <option value="editor"<?php if ($user['role'] === 'editor') echo ' selected'; ?>>Editor</option>
     <option value="admin"<?php if ($user['role'] === 'admin') echo ' selected'; ?>>Admin</option>
 </select>
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />

--- a/sql/001_create_users_table.sql
+++ b/sql/001_create_users_table.sql
@@ -3,5 +3,5 @@ CREATE TABLE IF NOT EXISTS users (
   id INT AUTO_INCREMENT PRIMARY KEY,
   email VARCHAR(255) NOT NULL UNIQUE,
   password_hash VARCHAR(255) NOT NULL,
-  role VARCHAR(50) NOT NULL
+  role ENUM('admin','editor','viewer') NOT NULL DEFAULT 'viewer'
 );


### PR DESCRIPTION
## Summary
- Add ENUM role field with default viewer in users table
- Support array-based role checks and gate admin pages by role
- Allow admins to assign viewer, editor, or admin roles in user management UI

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d3c10bf083288dde2f203472a139