### PR TITLE
Add localization and theme switcher to admin UI

### DIFF
--- a/public/admin/i18n.php
+++ b/public/admin/i18n.php
@@ -1,0 +1,31 @@
+<?php
+function get_locale(): string {
+    if (!empty($_COOKIE['locale'])) {
+        return preg_replace('/[^a-z]/', '', $_COOKIE['locale']);
+    }
+    $header = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '';
+    if (stripos($header, 'no') === 0) {
+        return 'no';
+    }
+    return 'en';
+}
+
+function load_translations(): array {
+    static $translations = null;
+    if ($translations === null) {
+        $locale = get_locale();
+        $file = __DIR__ . '/../locales/' . $locale . '.json';
+        if (!file_exists($file)) {
+            $file = __DIR__ . '/../locales/en.json';
+        }
+        $json = file_get_contents($file);
+        $translations = json_decode($json, true) ?? [];
+    }
+    return $translations;
+}
+
+function t(string $key): string {
+    $translations = load_translations();
+    return $translations[$key] ?? $key;
+}
+?>

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -1,24 +1,25 @@
 <?php
 $requireLogin = false;
 require_once 'auth.php';
+require_once 'i18n.php';
 if (!empty($_SESSION['user_id'])) {
     header('Location: articles/index.php');
     exit;
 }
 ?>
 <!DOCTYPE html>
-<html lang="no">
+<html lang="<?php echo get_locale(); ?>">
 <head>
 <meta charset="UTF-8" />
-<title>Admin-login</title>
+<title><?php echo t('admin_login'); ?></title>
 <link rel="stylesheet" href="/styles/main.css" />
 </head>
 <body>
-<h1>Admin</h1>
+<h1><?php echo t('admin'); ?></h1>
 <form id="login-form">
-<input type="email" name="email" placeholder="E-post" />
-<input type="password" name="password" placeholder="Passord" />
-<button type="submit">Logg inn</button>
+<input type="email" name="email" placeholder="<?php echo t('email'); ?>" />
+<input type="password" name="password" placeholder="<?php echo t('password'); ?>" />
+<button type="submit"><?php echo t('login'); ?></button>
 </form>
 <link rel="stylesheet" href="/assets/adminLogin.css" />
 <script type="module" src="/admin/login.js"></script>

--- a/public/admin/layout.php
+++ b/public/admin/layout.php
@@ -1,41 +1,44 @@
 <?php
 require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/i18n.php';
 
 function user_can(array $roles): bool {
     return in_array($_SESSION['role'] ?? '', $roles, true);
 }
 
 function admin_header(array $options = []): void {
-    $title = $options['title'] ?? 'Admin';
+    $title = $options['title'] ?? t('admin');
     $page = $options['page'] ?? '';
     $breadcrumbs = $options['breadcrumbs'] ?? [];
     $help = $options['help'] ?? '';
     $role = $_SESSION['role'] ?? '';
     ?>
 <!DOCTYPE html>
-<html lang="no">
+<html lang="<?php echo get_locale(); ?>">
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title><?php echo htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
 <link rel="stylesheet" href="/styles/admin.css" />
+<script>(function(){const t=localStorage.getItem('theme')|| (window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);})();</script>
 </head>
 <body>
 <header class="admin-header">
-  <div class="logo"><a href="/admin/articles/">GameNight Admin</a></div>
+  <div class="logo"><a href="/admin/articles/"><?php echo t('admin_title'); ?></a></div>
+  <button id="theme-toggle" class="theme-toggle" aria-label="<?php echo t('toggle_theme'); ?>">🌓</button>
 </header>
 <div class="admin-wrapper">
 <aside class="admin-sidebar">
   <ul>
     <?php if (user_can(['admin','editor'])): ?>
-    <li<?php if ($page === 'articles') echo ' class="active"'; ?>><a href="/admin/articles/">Artikler</a></li>
-    <li<?php if ($page === 'collections') echo ' class="active"'; ?>><a href="/admin/collections/">Samlinger</a></li>
-    <li<?php if ($page === 'games') echo ' class="active"'; ?>><a href="/admin/games/">Spill</a></li>
+    <li<?php if ($page === 'articles') echo ' class="active"'; ?>><a href="/admin/articles/"><?php echo t('articles'); ?></a></li>
+    <li<?php if ($page === 'collections') echo ' class="active"'; ?>><a href="/admin/collections/"><?php echo t('collections'); ?></a></li>
+    <li<?php if ($page === 'games') echo ' class="active"'; ?>><a href="/admin/games/"><?php echo t('games'); ?></a></li>
     <?php endif; ?>
     <?php if (user_can(['admin'])): ?>
-    <li<?php if ($page === 'users') echo ' class="active"'; ?>><a href="/admin/users/">Brukere</a></li>
-    <li<?php if ($page === 'settings') echo ' class="active"'; ?>><a href="/admin/settings/">Innstillinger</a></li>
-    <li<?php if ($page === 'audit_logs') echo ' class="active"'; ?>><a href="/admin/audit_logs/">Audit Logs</a></li>
+    <li<?php if ($page === 'users') echo ' class="active"'; ?>><a href="/admin/users/"><?php echo t('users'); ?></a></li>
+    <li<?php if ($page === 'settings') echo ' class="active"'; ?>><a href="/admin/settings/"><?php echo t('settings'); ?></a></li>
+    <li<?php if ($page === 'audit_logs') echo ' class="active"'; ?>><a href="/admin/audit_logs/"><?php echo t('audit_logs'); ?></a></li>
     <?php endif; ?>
   </ul>
 </aside>
@@ -62,6 +65,7 @@ function admin_footer(): void {
     ?>
 </main>
 </div>
+<script type="module" src="/admin/theme.js"></script>
 </body>
 </html>
 <?php

--- a/public/admin/theme.js
+++ b/public/admin/theme.js
@@ -1,0 +1,8 @@
+const toggle = document.getElementById('theme-toggle');
+if (toggle) {
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', current);
+    localStorage.setItem('theme', current);
+  });
+}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,0 +1,15 @@
+{
+  "admin_title": "GameNight Admin",
+  "articles": "Articles",
+  "collections": "Collections",
+  "games": "Games",
+  "users": "Users",
+  "settings": "Settings",
+  "audit_logs": "Audit Logs",
+  "email": "Email",
+  "password": "Password",
+  "login": "Log in",
+  "admin_login": "Admin Login",
+  "admin": "Admin",
+  "toggle_theme": "Toggle theme"
+}

--- a/public/locales/no.json
+++ b/public/locales/no.json
@@ -1,0 +1,15 @@
+{
+  "admin_title": "GameNight Admin",
+  "articles": "Artikler",
+  "collections": "Samlinger",
+  "games": "Spill",
+  "users": "Brukere",
+  "settings": "Innstillinger",
+  "audit_logs": "Audit Logs",
+  "email": "E-post",
+  "password": "Passord",
+  "login": "Logg inn",
+  "admin_login": "Admin-login",
+  "admin": "Admin",
+  "toggle_theme": "Bytt tema"
+}

--- a/public/styles/admin.css
+++ b/public/styles/admin.css
@@ -1,26 +1,60 @@
+:root {
+  --bg: #f4f4f4;
+  --text: #333;
+  --header-bg: #222;
+  --header-text: #fff;
+  --sidebar-bg: #333;
+  --sidebar-text: #fff;
+  --link: #555;
+  --help-bg: #eef;
+  --help-border: #ccd;
+}
+[data-theme="dark"] {
+  --bg: #222;
+  --text: #eee;
+  --header-bg: #000;
+  --header-text: #fff;
+  --sidebar-bg: #111;
+  --sidebar-text: #fff;
+  --link: #bbb;
+  --help-bg: #333;
+  --help-border: #555;
+}
+
 body {
   margin: 0;
   font-family: 'Segoe UI', sans-serif;
-  background: #f4f4f4;
-  color: #333;
+  background: var(--bg);
+  color: var(--text);
 }
 .admin-header {
-  background: #222;
-  color: #fff;
+  background: var(--header-bg);
+  color: var(--header-text);
   padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 .admin-header .logo a {
-  color: #fff;
+  color: var(--header-text);
   text-decoration: none;
   font-weight: bold;
+}
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--header-text);
+  cursor: pointer;
+  font-size: 1rem;
+  margin-left: 1rem;
 }
 .admin-wrapper {
   display: flex;
   min-height: 100vh;
 }
 .admin-sidebar {
-  background: #333;
-  color: #fff;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
   width: 200px;
   padding: 1rem;
 }
@@ -33,7 +67,7 @@ body {
   margin-bottom: 0.5rem;
 }
 .admin-sidebar a {
-  color: #fff;
+  color: var(--sidebar-text);
   text-decoration: none;
 }
 .admin-sidebar li.active a {
@@ -48,12 +82,12 @@ body {
   margin-bottom: 1rem;
 }
 .breadcrumbs a {
-  color: #555;
+  color: var(--link);
   text-decoration: none;
 }
 .help {
-  background: #eef;
-  border: 1px solid #ccd;
+  background: var(--help-bg);
+  border: 1px solid var(--help-border);
   padding: 0.5rem;
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- externalize admin strings into locale JSON files with PHP translation helper
- add light/dark theme toggle persisting preference via localStorage
- update admin CSS to use theme variables

## Testing
- `npm test`
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d5989840832894c67a3a65e6cb59