### PR TITLE
Add sequential challenge placeholders and tests

### DIFF
--- a/__tests__/placeholderReplacement.test.js
+++ b/__tests__/placeholderReplacement.test.js
@@ -1,0 +1,21 @@
+import { createPlaceholderReplacer } from '../src/components/ChallengeCard.js';
+
+describe('placeholder replacer', () => {
+  test('cycles through players with {{next}}', () => {
+    const replace = createPlaceholderReplacer(['Alice', 'Bob', 'Charlie']);
+    expect(replace('Player: {{next}}')).toBe('Player: Alice');
+    expect(replace('Player: {{next}}')).toBe('Player: Bob');
+    expect(replace('Player: {{next}}')).toBe('Player: Charlie');
+    expect(replace('Player: {{next}}')).toBe('Player: Alice');
+  });
+
+  test('selects oldest player with {{oldest}}', () => {
+    const players = [
+      { name: 'Anna', age: 20 },
+      { name: 'Ben', age: 35 },
+      { name: 'Chris', age: 30 }
+    ];
+    const replace = createPlaceholderReplacer(players);
+    expect(replace('Oldest is {{oldest}}')).toBe('Oldest is Ben');
+  });
+});

--- a/public/components/ChallengeCard.js
+++ b/public/components/ChallengeCard.js
@@ -1,3 +1,36 @@
+export function createPlaceholderReplacer(players) {
+  let nextIndex = 0;
+
+  const getName = p => (typeof p === 'object' && p.name) ? p.name : p;
+  const getAge = p => (typeof p === 'object' && typeof p.age === 'number') ? p.age : 0;
+
+  const handlers = {
+    player: () => {
+      const index = Math.floor(Math.random() * players.length);
+      return getName(players[index]);
+    },
+    next: () => {
+      const player = players[nextIndex % players.length];
+      nextIndex = (nextIndex + 1) % players.length;
+      return getName(player);
+    },
+    oldest: () => {
+      const oldest = players.reduce((prev, curr) => (
+        getAge(curr) > getAge(prev) ? curr : prev
+      ), players[0]);
+      return getName(oldest);
+    }
+  };
+
+  return function(text) {
+    if (players.length === 0) return text;
+    return text.replace(/{{(\w+)}}/gi, (match, token) => {
+      const handler = handlers[token.toLowerCase()];
+      return handler ? handler() : match;
+    });
+  };
+}
+
 export function showChallenge(collection, opts = {}) {
   const {
     containerId = 'app',
@@ -8,6 +41,7 @@ export function showChallenge(collection, opts = {}) {
   const app = document.getElementById(containerId);
   const shownIds = new Set();
   const players = JSON.parse(localStorage.getItem('players') || '[]');
+  const replacePlaceholders = createPlaceholderReplacer(players);
 
   const typeAssets = {
     challenge: {
@@ -37,14 +71,6 @@ export function showChallenge(collection, opts = {}) {
     const next = unused[Math.floor(Math.random() * unused.length)];
     shownIds.add(next.id);
     renderChallenge(next);
-  }
-
-  function replacePlaceholders(text) {
-    if (players.length === 0) return text;
-    return text.replace(/{{player}}/gi, () => {
-      const index = Math.floor(Math.random() * players.length);
-      return players[index];
-    });
   }
 
   function renderChallenge(challenge) {

--- a/src/components/ChallengeCard.js
+++ b/src/components/ChallengeCard.js
@@ -1,3 +1,36 @@
+export function createPlaceholderReplacer(players) {
+  let nextIndex = 0;
+
+  const getName = p => (typeof p === 'object' && p.name) ? p.name : p;
+  const getAge = p => (typeof p === 'object' && typeof p.age === 'number') ? p.age : 0;
+
+  const handlers = {
+    player: () => {
+      const index = Math.floor(Math.random() * players.length);
+      return getName(players[index]);
+    },
+    next: () => {
+      const player = players[nextIndex % players.length];
+      nextIndex = (nextIndex + 1) % players.length;
+      return getName(player);
+    },
+    oldest: () => {
+      const oldest = players.reduce((prev, curr) => (
+        getAge(curr) > getAge(prev) ? curr : prev
+      ), players[0]);
+      return getName(oldest);
+    }
+  };
+
+  return function(text) {
+    if (players.length === 0) return text;
+    return text.replace(/{{(\w+)}}/gi, (match, token) => {
+      const handler = handlers[token.toLowerCase()];
+      return handler ? handler() : match;
+    });
+  };
+}
+
 export function showChallenge(collection, opts = {}) {
   const {
     containerId = 'app',
@@ -8,6 +41,7 @@ export function showChallenge(collection, opts = {}) {
   const app = document.getElementById(containerId);
   const shownIds = new Set();
   const players = JSON.parse(localStorage.getItem('players') || '[]');
+  const replacePlaceholders = createPlaceholderReplacer(players);
 
   const typeAssets = {
     challenge: {
@@ -37,14 +71,6 @@ export function showChallenge(collection, opts = {}) {
     const next = unused[Math.floor(Math.random() * unused.length)];
     shownIds.add(next.id);
     renderChallenge(next);
-  }
-
-  function replacePlaceholders(text) {
-    if (players.length === 0) return text;
-    return text.replace(/{{player}}/gi, () => {
-      const index = Math.floor(Math.random() * players.length);
-      return players[index];
-    });
   }
 
   function renderChallenge(challenge) {


### PR DESCRIPTION
## Summary
- enhance challenge placeholder replacement to support `{{next}}`, `{{oldest}}`, and future tokens
- track player order locally so `{{next}}` cycles through participants
- add unit tests verifying new placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d9a012648328a14bcec3f1d1dc1f