### PR TITLE
feat: add offline fallback and API caching

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Offline</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    body { display:flex; align-items:center; justify-content:center; height:100vh; font-family:Arial, sans-serif; background:#f5f5f5; margin:0; }
+    h1 { color:#333; }
+  </style>
+</head>
+<body>
+  <h1>You're offline</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated offline page
- pre-cache offline fallback and cache API responses
- serve cached or offline content when network is unavailable

## Testing
- `npm test`
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dbccec588328ac2c6e54af3a2203