### PR TITLE
Use env-based analytics config with caching

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,10 +23,12 @@ Denne guiden beskriver hvordan du setter opp GameNight på en egen server.
 4. **Sett admin-passord**
    - Generer et bcrypt-hash av ønsket admin-passord.
    - Sett miljøvariabelen `ADMIN_PASS_HASH` til denne verdien.
-5. **Aktiver HTTPS og caching**
+5. **Konfigurer analyse**
+   - Sett miljøvariablene `ANALYTICS_MEASUREMENT_ID`, `ANALYTICS_ANONYMIZE_IP` og `ANALYTICS_RESPECT_DNT` etter behov.
+6. **Aktiver HTTPS og caching**
    - PWA-funksjonalitet krever at nettstedet kjøres over HTTPS.
    - Sørg for at `manifest.json` og `service-worker.js` serveres med korrekte MIME-typer.
-6. **Test installasjonen**
+7. **Test installasjonen**
    - Åpne siden i en nettleser og bekreft at utfordringer lastes og at appen fungerer offline etter første besøk.
 
 ## Spillmodussamlinger


### PR DESCRIPTION
## Summary
- read analytics configuration from environment variables instead of database
- add Cache-Control and ETag headers to analytics API
- document analytics configuration variables for deployment

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e034f83c8328bd1fdb08a6bed0a3