### PR TITLE
feat: add offline fallback page

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,6 +31,9 @@ Denne guiden beskriver hvordan du setter opp GameNight på en egen server.
 7. **Test installasjonen**
    - Åpne siden i en nettleser og bekreft at utfordringer lastes og at appen fungerer offline etter første besøk.
 
+## Offline-side
+Service-workeren cacher `offline.html` under installasjonen. Hvis nettverksforespørsler feiler og ingen cachet versjon finnes, vises denne siden automatisk. Tilpass innholdet i `public/offline.html` etter behov.
+
 ## Spillmodussamlinger
 Applikasjonen forsøker først å laste en statisk JSON-fil for en spillmodus fra `/data/collections/<GAMECODE>.json`.
 Hvis filen ikke finnes, faller den tilbake til API-et (`/api/collection.php?gamecode=<GAMECODE>`).

--- a/public/offline.html
+++ b/public/offline.html
@@ -5,11 +5,13 @@
   <title>Offline</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <style>
-    body { display:flex; align-items:center; justify-content:center; height:100vh; font-family:Arial, sans-serif; background:#f5f5f5; margin:0; }
+    body { display:flex; align-items:center; justify-content:center; height:100vh; font-family:Arial, sans-serif; background:#f5f5f5; margin:0; text-align:center; }
     h1 { color:#333; }
+    p { color:#666; }
   </style>
 </head>
 <body>
   <h1>You're offline</h1>
+  <p>Please check your connection and try again.</p>
 </body>
 </html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,7 @@
 const CACHE_VERSION = 'v3';
 const CACHE_NAME = `gamenight-cache-${CACHE_VERSION}`;
 const RUNTIME_CACHE = 'runtime-cache-v1';
+const OFFLINE_URL = '/offline.html';
 const PRECACHE_URLS = [
   '/',
   '/index.html',
@@ -22,14 +23,13 @@ const PRECACHE_URLS = [
   '/titles/challenge.png',
   '/titles/jegharaldri.png',
   '/titles/spillthetea.png',
-  '/titles/yayornay.png',
-  '/offline.html'
+  '/titles/yayornay.png'
 ];
 
 self.addEventListener('install', event => {
   console.log('Service Worker installing...');
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then(cache => cache.addAll([...PRECACHE_URLS, OFFLINE_URL]))
   );
 });
 
@@ -62,7 +62,7 @@ self.addEventListener('fetch', event => {
           return response;
         } catch (err) {
           const cached = await cache.match(event.request);
-          return cached || caches.match('/offline.html');
+          return cached || caches.match(OFFLINE_URL);
         }
       })
     );
@@ -81,7 +81,7 @@ self.addEventListener('fetch', event => {
           return response;
         } catch (err) {
           const cached = await cache.match(event.request);
-          return cached || caches.match('/offline.html');
+          return cached || caches.match(OFFLINE_URL);
         }
       })
     );
@@ -92,7 +92,7 @@ self.addEventListener('fetch', event => {
     event.respondWith(
       fetch(event.request).catch(async () => {
         const cached = (await caches.match(event.request)) || (await caches.match('/index.html'));
-        return cached || caches.match('/offline.html');
+        return cached || caches.match(OFFLINE_URL);
       })
     );
     return;
@@ -116,7 +116,7 @@ self.addEventListener('fetch', event => {
           }
           return response;
         })
-        .catch(() => cached || caches.match('/offline.html'));
+        .catch(() => cached || caches.match(OFFLINE_URL));
       return cached || fetchPromise;
     })
   );


### PR DESCRIPTION
## Summary
- cache offline page during service worker install
- show offline.html when network requests fail
- document offline fallback during deployment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac11cb7f388328917bf3eb94dc3fd1