### PR TITLE
Add role-based access control and management

### DIFF
--- a/public/admin/auth.php
+++ b/public/admin/auth.php
@@ -7,17 +7,15 @@ session_set_cookie_params([
 ]);
 session_start();
 $requireLogin = $requireLogin ?? true;
-if ($requireLogin) {
-    if (empty($_SESSION['user_id'])) {
-        header('Location: index.php');
-        exit;
-    }
-    if (!empty($requireRole)) {
-        $roles = is_array($requireRole) ? $requireRole : [$requireRole];
-        if (!in_array($_SESSION['role'] ?? '', $roles, true)) {
-            http_response_code(403);
-            exit('Access denied');
-        }
+if ($requireLogin && empty($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+if (isset($requireRole)) {
+    $roles = is_array($requireRole) ? $requireRole : [$requireRole];
+    if (!in_array($_SESSION['role'] ?? '', $roles, true)) {
+        http_response_code(403);
+        exit('Access denied');
     }
 }
 ?>

--- a/public/admin/collections/external_edit.php
+++ b/public/admin/collections/external_edit.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+$requireRole = ['admin','editor'];
+require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }

--- a/public/admin/games/external_edit.php
+++ b/public/admin/games/external_edit.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+$requireRole = ['admin','editor'];
+require_once '../auth.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }

--- a/public/admin/users/edit.php
+++ b/public/admin/users/edit.php
@@ -1,6 +1,6 @@
 <?php
 $requireRole = 'admin';
-require_once '../auth.php';
+require_once '../layout.php';
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
@@ -55,14 +55,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8" />
-<title>Edit User</title>
-<link rel="stylesheet" href="/styles/main.css" />
-</head>
-<body>
+<?php
+$title = 'Edit User';
+$page = 'users';
+$breadcrumbs = [
+    ['label' => 'Users', 'url' => 'index.php'],
+    ['label' => 'Edit']
+];
+admin_header(compact('title','page','breadcrumbs'));
+?>
 <h1>Edit User</h1>
 <?php if (!empty($message)): ?><p style="color:green;"><?php echo $message; ?></p><?php endif; ?>
 <?php if (!empty($error)): ?><p style="color:red;"><?php echo $error; ?></p><?php endif; ?>
@@ -73,11 +74,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <option value="viewer"<?php if ($user['role'] === 'viewer') echo ' selected'; ?>>Viewer</option>
     <option value="editor"<?php if ($user['role'] === 'editor') echo ' selected'; ?>>Editor</option>
     <option value="admin"<?php if ($user['role'] === 'admin') echo ' selected'; ?>>Admin</option>
-</select>
+ </select>
 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>" />
 <button type="submit">Update</button>
 </form>
 <p>MFA: <?php echo $user['mfa_enabled'] ? 'Enabled' : 'Disabled'; ?><?php if ($user['mfa_enabled']): ?> (<a href="reset_mfa.php?id=<?php echo $user['id']; ?>">Reset MFA</a>)<?php endif; ?></p>
 <p><a href="index.php">Back to users</a></p>
-</body>
-</html>
+<?php admin_footer(); ?>

--- a/public/api/auth.php
+++ b/public/api/auth.php
@@ -47,7 +47,7 @@ if ($user && password_verify($password, $user['password_hash'])) {
     $_SESSION['role'] = $user['role'];
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     log_audit($pdo, (int)$user['id'], 'login', '', ['ip' => $_SERVER['REMOTE_ADDR'] ?? '']);
-    echo json_encode(['success' => true]);
+    echo json_encode(['success' => true, 'role' => $user['role']]);
 } else {
     http_response_code(401);
     echo json_encode(['error' => 'Invalid credentials']);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,4 +1,13 @@
 -- SQL schema for GameNight blog and collections
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  role ENUM('admin','editor','viewer') NOT NULL DEFAULT 'viewer',
+  mfa_secret VARCHAR(255) DEFAULT NULL,
+  mfa_enabled TINYINT(1) NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS posts (
   id INT AUTO_INCREMENT PRIMARY KEY,
   slug VARCHAR(100) NOT NULL UNIQUE,


### PR DESCRIPTION
## Summary
- add users table with role column to schema
- enforce role gates across admin pages and external editing endpoints
- expose and manage user roles via API and admin UI

## Testing
- `npm test`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ac12ae7f888328b8cd10c8767f4253