### PR TITLE
Prevent installer and updater scripts from reappearing

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,7 @@
 2. When confirmed it downloads the latest release from the repository, backs up existing files, extracts the update, and restores your `.env`.
 3. Composer dependencies and database migrations are executed automatically.
 4. `version.txt` is updated and you are prompted that the update is complete. **Delete `update.php`** when finished.
+5. The updater skips `install.php` and `update.php`, so once removed these scripts stay absent in future releases.
 
 ## Security Notes
 - Restrict access to `install.php` and `update.php` or remove them entirely after use.

--- a/public/update.php
+++ b/public/update.php
@@ -61,7 +61,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     recurseCopy(__DIR__.'/..', $backupDir, ['vendor','node_modules','backup']);
 
     $extractedRoot = glob($tmpDir.'/*')[0] ?? $tmpDir;
-    recurseCopy($extractedRoot, __DIR__.'/..', ['.env','installed.lock','backup']);
+    recurseCopy(
+        $extractedRoot,
+        __DIR__.'/..',
+        ['.env','installed.lock','backup','install.php','update.php']
+    );
     if (file_exists($backupDir.'/.env')) {
         copy($backupDir.'/.env', __DIR__.'/../.env');
     }


### PR DESCRIPTION
## Summary
- Ignore install.php and update.php when copying new release files during update
- Clarify in installation docs that these scripts stay absent once removed

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac18b8a3548328820933fdf2b2f0fc