### PR TITLE
Add dynamic ads.txt and ad slot support

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,11 @@
+<?php
+header('Content-Type: text/plain');
+require_once __DIR__ . '/api/db.php';
+
+$stmt = $pdo->prepare('SELECT value FROM settings WHERE name = ?');
+$stmt->execute(['integrations_adsense_publisher_id']);
+$publisherId = $stmt->fetchColumn();
+
+if ($publisherId) {
+    echo "google.com, {$publisherId}, DIRECT, f08c47fec0942fa0";
+}

--- a/public/components/Ads.js
+++ b/public/components/Ads.js
@@ -1,9 +1,9 @@
 import { renderAdSlot } from '../ads.js';
 
-export function renderBannerAd(containerId = 'ad-banner') {
-  renderAdSlot(containerId, 'banner');
+export function renderBannerAd(containerId = 'ad-banner', slotId) {
+  renderAdSlot(containerId, 'banner', slotId);
 }
 
-export function renderSidebarAd(containerId = 'ad-sidebar') {
-  renderAdSlot(containerId, 'sidebar');
+export function renderSidebarAd(containerId = 'ad-sidebar', slotId) {
+  renderAdSlot(containerId, 'sidebar', slotId);
 }

--- a/src/ads.js
+++ b/src/ads.js
@@ -18,13 +18,17 @@ export async function initAds() {
   }
 }
 
-export function renderAdSlot(containerId, type = 'banner') {
+export function renderAdSlot(containerId, type = 'banner', slotId) {
   if (!publisherId) return;
   const container = document.getElementById(containerId);
   if (!container) return;
   const ins = document.createElement('ins');
   ins.className = 'adsbygoogle';
   ins.setAttribute('data-ad-client', publisherId);
+  const slot = slotId || container.dataset.adSlot;
+  if (slot) {
+    ins.setAttribute('data-ad-slot', slot);
+  }
   if (type === 'sidebar') {
     ins.style.display = 'block';
     ins.style.width = '300px';

--- a/src/components/Ads.js
+++ b/src/components/Ads.js
@@ -1,9 +1,9 @@
 import { renderAdSlot } from '../ads.js';
 
-export function renderBannerAd(containerId = 'ad-banner') {
-  renderAdSlot(containerId, 'banner');
+export function renderBannerAd(containerId = 'ad-banner', slotId) {
+  renderAdSlot(containerId, 'banner', slotId);
 }
 
-export function renderSidebarAd(containerId = 'ad-sidebar') {
-  renderAdSlot(containerId, 'sidebar');
+export function renderSidebarAd(containerId = 'ad-sidebar', slotId) {
+  renderAdSlot(containerId, 'sidebar', slotId);
 }


### PR DESCRIPTION
## Summary
- serve `ads.txt` by reading the AdSense publisher ID from settings
- allow specifying `data-ad-slot` on ad render helpers

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac207fba148328b35af7c5a73e1b21